### PR TITLE
Remove unnecessary help docstrings

### DIFF
--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -260,9 +260,7 @@ class F15_Bootloader(F14_Bootloader):
                         If given, the password specified by ``--password=`` is
                         already encrypted and should be passed to the bootloader
                         configuration without additional modification.""")
-        op.add_argument("--md5pass", dest="_md5pass", version=F15, help="""
-                        If using GRUB, similar to ``--password=`` except the password
-                        should already be encrypted.""")
+        op.add_argument("--md5pass", dest="_md5pass", version=F15, help="")
         return op
 
     def parse(self, args):
@@ -386,9 +384,7 @@ class RHEL6_Bootloader(F12_Bootloader):
                         If given, the password specified by ``--password=`` is
                         already encrypted and should be passed to the bootloader
                         configuration without additional modification.""")
-        op.add_argument("--md5pass", dest="_md5pass", version=RHEL6, help="""
-                        If using GRUB, similar to ``--password=`` except the
-                        password should already be encrypted.""")
+        op.add_argument("--md5pass", dest="_md5pass", version=RHEL6, help="")
         return op
 
     def parse(self, args):


### PR DESCRIPTION
In the online documentation for the `bootloader` command
(Fedora: http://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#bootloader
RHEL: http://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#id4)
under the `--md5pass` optional argument, the text "If using GRUB [...] already be encrypted." appears twice:
![md5pass](https://cloud.githubusercontent.com/assets/25583206/22797260/4a8c3354-ef06-11e6-9826-ab6474abb412.png)