### PR TITLE
Drop python2 compatibility

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -1,9 +1,3 @@
-%if 0%{?rhel} > 7
-%bcond_with python2
-%else
-%bcond_without python2
-%endif
-
 # Disable tests by default because they fail to run inside mock builds
 # at the moment, but can run locally.  To build and run tests, do:
 #     rpmbuild -ba --with runtests pykickstart.spec
@@ -21,15 +15,6 @@ Source1:   https://github.com/pykickstart/%{name}/releases/download/r%{version}/
 BuildArch: noarch
 
 BuildRequires: gettext
-%if %{with python2}
-BuildRequires: python2-coverage
-BuildRequires: python2-devel
-BuildRequires: python2-nose
-BuildRequires: python2-ordered-set
-BuildRequires: python2-setuptools
-BuildRequires: python2-requests
-%endif
-
 BuildRequires: python3-coverage
 BuildRequires: python3-devel
 BuildRequires: python3-nose
@@ -42,26 +27,8 @@ BuildRequires: python3-sphinx
 Requires: python3-kickstart = %{version}-%{release}
 
 %description
-Python utilities for manipulating kickstart files.  The Python 2 and 3
-libraries can be found in the packages python-kickstart and python3-kickstart
-respectively.
+Python utilities for manipulating kickstart files.
 
-%if %{with python2}
-# Python 2 library
-%package -n python2-kickstart
-%{?python_provide:%python_provide python2-kickstart}
-%{?python_provide:%python_provide python2-pykickstart}
-Summary:  Python 2 library for manipulating kickstart files.
-Requires: python2-six
-Requires: python2-requests
-Requires: python2-ordered-set
-
-%description -n python2-kickstart
-Python 2 library for manipulating kickstart files.  The binaries are found in
-the pykickstart package.
-%endif
-
-# Python 3 library
 %package -n python3-kickstart
 Summary:  Python 3 library for manipulating kickstart files.
 Requires: python3-six
@@ -75,35 +42,15 @@ the pykickstart package.
 %prep
 %setup -q
 
-%if %{with python2}
-rm -rf %{py3dir}
-mkdir %{py3dir}
-cp -a . %{py3dir}
-%endif
-
 %build
-%if %{with python2}
-make PYTHON=%{__python2}
-make -C %{py3dir} PYTHON=%{__python3}
-%else
 make PYTHON=%{__python3}
-%endif
 
 %install
-%if %{with python2}
-make PYTHON=%{__python2} DESTDIR=%{buildroot} install
-make -C %{py3dir} PYTHON=%{__python3} DESTDIR=%{buildroot} install
-%else
 make PYTHON=%{__python3} DESTDIR=%{buildroot} install
-%endif
 
 %check
 %if %{with runtests}
-%if %{with python2}
-make -C %{py3dir} PYTHON=%{__python3} test
-%else
 make PYTHON=%{__python3} test
-%endif
 %endif
 
 %files
@@ -118,15 +65,6 @@ make PYTHON=%{__python3} test
 %{_mandir}/man1/ksshell.1.gz
 %{_mandir}/man1/ksvalidator.1.gz
 %{_mandir}/man1/ksverdiff.1.gz
-
-%if %{with python2}
-%files -n python2-kickstart
-%doc docs/2to3
-%doc docs/programmers-guide
-%doc docs/kickstart-docs.txt
-%{python2_sitelib}/pykickstart*.egg-info
-%{python2_sitelib}/pykickstart
-%endif
 
 %files -n python3-kickstart
 %doc docs/2to3


### PR DESCRIPTION
Right now on Rawhide (F32) pykickstart can't be build because
python2-ordered-set and python2-requests do not exists anymore.

The best approach seems to me to drop python2 compatibility and support
pykickstart only as python3 from now on.

---------------------

I don't insist on this solution but it would be great to make the spec file in the upstream working. What do you think @bcl ?