### PR TITLE
Add lowercase aliases for camelCased %packages options

### DIFF
--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -290,6 +290,32 @@ class F25_Timezone(F23_Timezone):
         F23_Timezone.__init__(self, writePriority, *args, **kwargs)
         self.op = self._getParser()
 
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+        args = self._getArgsAsStr()
+        if args:
+            retval += "# System timezone\n"
+            retval += "timezone" + args + "\n"
+
+        return retval
+
+    def _getArgsAsStr(self):
+        retval = ""
+
+        if self.timezone:
+            retval += " " + self.timezone
+
+        if self.isUtc:
+            retval += " --isUtc"
+
+        if self.nontp:
+            retval += " --nontp"
+
+        if self.ntpservers:
+            retval += " --ntpservers=" + ",".join(self.ntpservers)
+
+        return retval
+
     def _getParser(self):
         op = KSOptionParser(prog="timezone", description="""
                             This required command sets the system time zone to

--- a/pykickstart/handlers/f32.py
+++ b/pykickstart/handlers/f32.py
@@ -84,7 +84,7 @@ class F32Handler(BaseHandler):
         "sshpw": commands.sshpw.F24_SshPw,
         "sshkey": commands.sshkey.F22_SshKey,
         "text": commands.displaymode.F26_DisplayMode,
-        "timezone": commands.timezone.F25_Timezone,
+        "timezone": commands.timezone.F32_Timezone,
         "updates": commands.updates.F7_Updates,
         "url": commands.url.F30_Url,
         "user": commands.user.F24_User,

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -391,11 +391,11 @@ class Packages(KickstartObject):
         if self.handleBroken == constants.KS_BROKEN_IGNORE:
             retval += " --ignorebroken"
         if self.instLangs is not None:
-            retval += " --instLangs=%s" % self.instLangs
+            retval += " --inst-langs=%s" % self.instLangs
         if self.multiLib:
             retval += " --multilib"
         if self.excludeWeakdeps:
-            retval += " --excludeWeakdeps"
+            retval += " --exclude-weakdeps"
         if self.timeout is not None:
             retval += " --timeout=%d" % self.timeout
         if self.retries is not None:

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -29,11 +29,12 @@ treated just the same as a predefined one by the kickstart parser.  All that
 is necessary is to create a new subclass of Section and call
 parser.registerSection with an instance of your new class.
 """
+import warnings
 from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACEBACK, \
                                   KS_SCRIPT_PREINSTALL, KS_SCRIPT_ONERROR, \
                                   KS_MISSING_IGNORE, KS_MISSING_PROMPT, \
                                   KS_BROKEN_IGNORE, KS_BROKEN_REPORT
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.options import KSOptionParser
 from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, RHEL6, RHEL7
 from pykickstart.i18n import _
@@ -766,3 +767,12 @@ class PackageSection(Section):
             self.handler.packages.handleBroken = KS_BROKEN_IGNORE
         else:
             self.handler.packages.handleBroken = KS_BROKEN_REPORT
+
+        for option, new_option in \
+                {"--instLangs": "--inst-langs", "--excludeWeakdeps": "--exclude-weakdeps"}.items():
+            if option in args:
+                warnings.warn(_("The %(option)s option on line %(lineno)s will be deprecated in"
+                                "future releases. Please modify your kickstart file to replace"
+                                "this option with its preferred alias %(new_option)s.")
+                              % {"option": option, "lineno": lineno, "new_option": new_option},
+                              KickstartDeprecationWarning)

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -615,7 +615,7 @@ class PackageSection(Section):
 
         op.remove_argument("--ignoredeps", version=F9)
         op.remove_argument("--resolvedeps", version=F9)
-        op.add_argument("--instLangs", default=None, version=F9, help="""
+        op.add_argument("--instLangs", "--inst-langs", default=None, version=F9, help="""
                         Specify the list of languages that should be installed.
                         This is different from the package group level
                         selections, though. This option does not specify what
@@ -674,7 +674,7 @@ class PackageSection(Section):
         if self.version < F24:
             return op
 
-        op.add_argument("--excludeWeakdeps", dest="excludeWeakdeps",
+        op.add_argument("--excludeWeakdeps", "--exclude-weakdeps", dest="excludeWeakdeps",
                         action="store_true", default=False, version=F24,
                         help="""
                         Do not install packages from weak dependencies. These

--- a/tests/args_names.py
+++ b/tests/args_names.py
@@ -1,0 +1,79 @@
+import unittest
+import shlex
+import re
+
+from pykickstart.parser import KickstartParser
+from pykickstart.sections import NullSection
+from pykickstart.version import makeVersion
+
+VALID_KICKSTART_OPTION_PATTERN = r"--[a-z0-9\-]+"
+
+
+class ArgumentNamesStatic_TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self._bad_options = []
+        self._reg_name_checker = re.compile(VALID_KICKSTART_OPTION_PATTERN)
+        self._handler = makeVersion()
+
+    def runTest(self):
+        self._check_commands()
+        self._check_sections()
+        self._report()
+
+    def _check_sections(self):
+
+        tmp_parser = KickstartParser(self._handler)
+        # KickstartParser registers internally all sections, so it is possible to get the names and
+        # instances from there. However, it handles some known sections implemented outside
+        # pykickstart by using NullSection instead of the actual class.
+
+        for section, instance in tmp_parser._sections.items():
+            if not isinstance(instance, NullSection):
+                arg_parser = instance._getParser()
+                self._check_parser_actions(arg_parser, section)
+
+    def _check_commands(self):
+
+        for command, cmdClass in self._handler.commandMap.items():
+
+            if command == "method":
+                continue
+
+            args = shlex.split(command, comments=True)
+            cmd = args[0]
+
+            ks_parser = self._handler.commands[cmd]
+            ks_parser.currentLine = command
+            ks_parser.currentCmd = args[0]
+            ks_parser.seen = True
+            arg_parser = ks_parser._getParser()
+
+            self._check_parser_actions(arg_parser, command, cmd_class=cmdClass)
+
+    def _check_parser_actions(self, arg_parser, cmd_name, cmd_class=None):
+
+        for action in arg_parser._get_optional_actions():
+            if action.deprecated:
+                continue
+
+            found_any_good = False
+            for option in action.option_strings:
+                if cmd_class and option.lstrip("-") in cmd_class.removedAttrs:
+                    # caution removedAttrs does not include leading dashes
+                    continue
+                is_good = self._reg_name_checker.fullmatch(option) is not None
+                found_any_good = found_any_good or is_good
+                if not is_good:
+                    print("Found option with uppercase letters: %s for command %s." % (option, cmd_name))
+
+            if not found_any_good:
+                self._bad_options.append(tuple((cmd_name, action.option_strings)))
+
+    def _report(self):
+        if self._bad_options:
+            print("The following kickstart option sets do not include a lowercase only variant:")
+            for option_set in self._bad_options:
+                print("%s: %s" % (option_set[0], ", ".join(option_set[1])))
+
+            self.fail("Some options use uppercase letters and do not have a lowercase-only alias.")

--- a/tests/commands/timezone.py
+++ b/tests/commands/timezone.py
@@ -138,10 +138,12 @@ class F25_TestCase(F23_TestCase):
     def runTest(self):
         # since RHEL7 command version the timezone command can be used
         # without a timezone specification
-        self.assert_parse("timezone --utc")
-        self.assert_parse("timezone --isUtc")
-        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz")
-        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz")
+        self.assert_parse("timezone --utc", "timezone --isUtc\n")
+        self.assert_parse("timezone --isUtc", "timezone --isUtc\n")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz", "timezone --ntpservers=ntp.cesnet.cz\n")
+        self.assert_parse("timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz", "timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz\n")
+        # normal usage
+        self.assert_parse("timezone Europe/Oslo --nontp", "timezone Europe/Oslo --nontp\n")
         # unknown argument
         self.assert_parse_error("timezone --blah")
         # more than two timezone specs


### PR DESCRIPTION
The majority of Kickstart options use lowercase hyphenated naming scheme. This adds the `--exclude-weakdeps` alias for `--excludeWeakdeps` and `--inst-langs` for `--instLangs`, which moves Kickstart a bit closer to consistency.