### PR TITLE
Remove url command doc that it's replaced

### DIFF
--- a/pykickstart/commands/url.py
+++ b/pykickstart/commands/url.py
@@ -175,10 +175,10 @@ class F18_Url(F14_Url):
     def _getParser(self):
         op = F14_Url._getParser(self)
         op.add_argument("--url", version=F18, help="""
-                        This parameter is no longer required because you could
-                        use ``--mirrorlist`` instead.""")
+                        The URL to install from. Variable substitution is done
+                        for $releasever and $basearch in the url.""")
         op.add_argument("--mirrorlist", metavar="URL", version=F18, help="""
-                        The mirror URL to install from. Variable substitution
+                        The mirrorlist URL to install from. Variable substitution
                         is done for $releasever and $basearch in the url.""")
         return op
 


### PR DESCRIPTION
URL command have still it's meaning. Not sure why this part of the documentation was added but `mirrorlist` does not replacing url.

Mirrorlist should be used for mirrorlist server, however, url should be used to point directly to the server repository.