### PR TITLE
Deprecate repo ignoregroups

### DIFF
--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -19,7 +19,7 @@
 #
 from textwrap import dedent
 from pykickstart.version import versionToLongString
-from pykickstart.version import FC6, F8, F11, F13, F14, F15, F21, F27, F30
+from pykickstart.version import FC6, F8, F11, F13, F14, F15, F21, F27, F30, F33
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser, commaSplit, ksboolean
@@ -476,6 +476,15 @@ class F30_Repo(F27_Repo):
                         **Note** Usage of this parameter is discouraged. It is
                         designed for a specific image building tool use and
                         there are plans for a replacement.""")
+        return op
+
+class F33_Repo(F30_Repo):
+    removedKeywords = F30_Repo.removedKeywords
+    removedAttrs = F30_Repo.removedAttrs
+
+    def _getParser(self):
+        op = F30_Repo._getParser(self)
+        op.add_argument("--ignoregroups", type=ksboolean, deprecated=F33)
         return op
 
 class RHEL7_Repo(F21_Repo):

--- a/pykickstart/handlers/f33.py
+++ b/pykickstart/handlers/f33.py
@@ -72,7 +72,7 @@ class F33Handler(BaseHandler):
         "raid": commands.raid.F29_Raid,
         "realm": commands.realm.F19_Realm,
         "reboot": commands.reboot.F23_Reboot,
-        "repo": commands.repo.F30_Repo,
+        "repo": commands.repo.F33_Repo,
         "reqpart": commands.reqpart.F23_ReqPart,
         "rescue": commands.rescue.F10_Rescue,
         "rootpw": commands.rootpw.F18_RootPw,

--- a/pykickstart/handlers/f33.py
+++ b/pykickstart/handlers/f33.py
@@ -1,0 +1,122 @@
+#
+# Copyright 2020 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+__all__ = ["F33Handler"]
+
+from pykickstart import commands
+from pykickstart.base import BaseHandler
+from pykickstart.version import F33
+
+class F33Handler(BaseHandler):
+    version = F33
+
+    commandMap = {
+        "auth": commands.authconfig.F28_Authconfig,
+        "authconfig": commands.authconfig.F28_Authconfig,
+        "authselect": commands.authselect.F28_Authselect,
+        "autopart": commands.autopart.F29_AutoPart,
+        "autostep": commands.autostep.FC3_AutoStep,
+        "bootloader": commands.bootloader.F29_Bootloader,
+        "btrfs": commands.btrfs.F23_BTRFS,
+        "cdrom": commands.cdrom.FC3_Cdrom,
+        "clearpart": commands.clearpart.F28_ClearPart,
+        "cmdline": commands.displaymode.F26_DisplayMode,
+        "device": commands.device.F24_Device,
+        "deviceprobe": commands.deviceprobe.F29_DeviceProbe,
+        "dmraid": commands.dmraid.F24_DmRaid,
+        "driverdisk": commands.driverdisk.F14_DriverDisk,
+        "module": commands.module.F31_Module,
+        "eula": commands.eula.F20_Eula,
+        "fcoe": commands.fcoe.F28_Fcoe,
+        "firewall": commands.firewall.F28_Firewall,
+        "firstboot": commands.firstboot.FC3_Firstboot,
+        "graphical": commands.displaymode.F26_DisplayMode,
+        "group": commands.group.F12_Group,
+        "halt": commands.reboot.F23_Reboot,
+        "harddrive": commands.harddrive.FC3_HardDrive,
+        "hmc": commands.hmc.F28_Hmc,
+        "ignoredisk": commands.ignoredisk.F29_IgnoreDisk,
+        "install": commands.install.F29_Install,
+        "iscsi": commands.iscsi.F17_Iscsi,
+        "iscsiname": commands.iscsiname.FC6_IscsiName,
+        "keyboard": commands.keyboard.F18_Keyboard,
+        "lang": commands.lang.F19_Lang,
+        "liveimg": commands.liveimg.F19_Liveimg,
+        "logging": commands.logging.FC6_Logging,
+        "logvol": commands.logvol.F29_LogVol,
+        "mediacheck": commands.mediacheck.FC4_MediaCheck,
+        "method": commands.method.F28_Method,
+        "mount": commands.mount.F27_Mount,
+        "multipath": commands.multipath.F24_MultiPath,
+        "network": commands.network.F27_Network,
+        "nfs": commands.nfs.FC6_NFS,
+        "nvdimm": commands.nvdimm.F28_Nvdimm,
+        "ostreesetup": commands.ostreesetup.F21_OSTreeSetup,
+        "part": commands.partition.F29_Partition,
+        "partition": commands.partition.F29_Partition,
+        "poweroff": commands.reboot.F23_Reboot,
+        "raid": commands.raid.F29_Raid,
+        "realm": commands.realm.F19_Realm,
+        "reboot": commands.reboot.F23_Reboot,
+        "repo": commands.repo.F30_Repo,
+        "reqpart": commands.reqpart.F23_ReqPart,
+        "rescue": commands.rescue.F10_Rescue,
+        "rootpw": commands.rootpw.F18_RootPw,
+        "selinux": commands.selinux.FC3_SELinux,
+        "services": commands.services.FC6_Services,
+        "shutdown": commands.reboot.F23_Reboot,
+        "skipx": commands.skipx.FC3_SkipX,
+        "snapshot": commands.snapshot.F26_Snapshot,
+        "sshpw": commands.sshpw.F24_SshPw,
+        "sshkey": commands.sshkey.F22_SshKey,
+        "text": commands.displaymode.F26_DisplayMode,
+        "timezone": commands.timezone.F32_Timezone,
+        "updates": commands.updates.F7_Updates,
+        "url": commands.url.F30_Url,
+        "user": commands.user.F24_User,
+        "vnc": commands.vnc.F9_Vnc,
+        "volgroup": commands.volgroup.F21_VolGroup,
+        "xconfig": commands.xconfig.F14_XConfig,
+        "zerombr": commands.zerombr.F9_ZeroMbr,
+        "zfcp": commands.zfcp.F14_ZFCP,
+        "zipl": commands.zipl.F32_Zipl,
+    }
+
+    dataMap = {
+        "BTRFSData": commands.btrfs.F23_BTRFSData,
+        "DriverDiskData": commands.driverdisk.F14_DriverDiskData,
+        "DeviceData": commands.device.F8_DeviceData,
+        "DmRaidData": commands.dmraid.FC6_DmRaidData,
+        "ModuleData": commands.module.F31_ModuleData,
+        "FcoeData": commands.fcoe.F28_FcoeData,
+        "GroupData": commands.group.F12_GroupData,
+        "IscsiData": commands.iscsi.F17_IscsiData,
+        "LogVolData": commands.logvol.F29_LogVolData,
+        "MountData": commands.mount.F27_MountData,
+        "MultiPathData": commands.multipath.FC6_MultiPathData,
+        "NetworkData": commands.network.F27_NetworkData,
+        "NvdimmData": commands.nvdimm.F28_NvdimmData,
+        "PartData": commands.partition.F29_PartData,
+        "RaidData": commands.raid.F29_RaidData,
+        "RepoData": commands.repo.F30_RepoData,
+        "SnapshotData": commands.snapshot.F26_SnapshotData,
+        "SshPwData": commands.sshpw.F24_SshPwData,
+        "SshKeyData": commands.sshkey.F22_SshKeyData,
+        "UserData": commands.user.F19_UserData,
+        "VolGroupData": commands.volgroup.F21_VolGroupData,
+        "ZFCPData": commands.zfcp.F14_ZFCPData,
+    }

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -90,10 +90,11 @@ F29 = 27000
 F30 = 30000
 F31 = 31000
 F32 = 32000
+F33 = 33000
 RHEL8 = 26100
 
 # This always points at the latest version and is the default.
-DEVEL = F32
+DEVEL = F33
 
 # A one-to-one mapping from string representations to version numbers.
 versionMap = {
@@ -103,7 +104,7 @@ versionMap = {
     "F14": F14, "F15": F15, "F16": F16, "F17": F17, "F18": F18,
     "F19": F19, "F20": F20, "F21": F21, "F22": F22, "F23": F23,
     "F24": F24, "F25": F25, "F26": F26, "F27": F27, "F28": F28,
-    "F29": F29, "F30": F30, "F31": F31, "F32": F32,
+    "F29": F29, "F30": F30, "F31": F31, "F32": F32, "F33": F33,
     "RHEL3": RHEL3, "RHEL4": RHEL4, "RHEL5": RHEL5, "RHEL6": RHEL6,
     "RHEL7": RHEL7, "RHEL8": RHEL8
 }

--- a/tests/commands/repo.py
+++ b/tests/commands/repo.py
@@ -21,7 +21,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 
-from pykickstart.errors import KickstartError, KickstartParseWarning
+from pykickstart.errors import KickstartError, KickstartParseWarning, KickstartDeprecationWarning
 from pykickstart.version import FC6
 
 class FC6_TestCase(CommandTest):
@@ -192,6 +192,15 @@ class F30_TestCase(F27_TestCase):
         self.assert_parse_error("repo --name=test --sslclientcert")
         self.assert_parse_error("repo --name=test --sslclientkey")
         self.assert_parse_error("repo --name=test --sslcacert")
+
+class F33_TestCase(F30_TestCase):
+    def runTest(self, urlRequired=False):
+        F30_TestCase.runTest(self, urlRequired=urlRequired)
+
+        self.assert_deprecated("repo", "--ignoregroups")
+        with self.assertWarns(KickstartDeprecationWarning):
+            self.assert_parse("repo --name=blah --baseurl=www.domain.com --ignoregroups=true")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/version.py
+++ b/tests/version.py
@@ -224,7 +224,8 @@ class VersionToString_TestCase(CommandTest):
         self.assertEqual(versionToString(F30, skipDevel=True), "F30")
         self.assertEqual(versionToString(F31, skipDevel=True), "F31")
         self.assertEqual(versionToString(F32, skipDevel=True), "F32")
-        self.assertEqual(versionToString(F32, skipDevel=False), "DEVEL")
+        self.assertEqual(versionToString(F33, skipDevel=True), "F33")
+        self.assertEqual(versionToString(F33, skipDevel=False), "DEVEL")
         # RHEL series
         self.assertEqual(versionToString(RHEL3), "RHEL3")
         self.assertEqual(versionToString(RHEL4), "RHEL4")


### PR DESCRIPTION
The ``repo --ignoregroups`` parameter is not used by Anaconda from yum -> dnf transition. I don't think we want to add it back but instead we can remove this from our API.

P.S.: Not sure if the deprecation is done correctly. Could you please verify that before merge @bcl.