### PR TITLE
Add Travis test for Python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 dist: xenial
 
-matrix:
+jobs:
   include:
     - name: "Python 3.5"
       python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ jobs:
       python: "3.7"
     - name: "Python 3.8"
       python: "3.8"
+    - name: "Python Nightly"
+      python: "nightly"
+  allow_failures:
+    - python: "nightly"
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 
 jobs:
   include:


### PR DESCRIPTION
Adding this check so devs can know in advance of a future Python release that `pykickstart` still works. This is more important now that Python has increased the release cycle. The test is allowed to fail.