### PR TITLE
Remove unneeded refs to deps

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -17,7 +17,6 @@ BuildArch: noarch
 BuildRequires: gettext
 BuildRequires: python3-coverage
 BuildRequires: python3-devel
-BuildRequires: python3-nose
 BuildRequires: python3-ordered-set
 BuildRequires: python3-requests
 BuildRequires: python3-setuptools

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,7 +1,7 @@
 Testing pykickstart
 ===================
 
-Pykickstart's test suite requires the nosetests Python package. To execute it
+To execute Pykickstart's test suite
 from inside the source directory run the command::
 
     make test

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -15,8 +15,6 @@ To execute the Pylint code analysis tool run::
 
     make check
 
-Running Pylint requires Python3 due to usage of pocket-lint.
-
 
 Test Suite Architecture
 ------------------------


### PR DESCRIPTION
* cleaned up references to `nose`
* removed explicitly calling out Python3 as a requirement since py2 is no longer supported