### PR TITLE
Remove harddrive --biospart support

### DIFF
--- a/pykickstart/handlers/f33.py
+++ b/pykickstart/handlers/f33.py
@@ -47,7 +47,7 @@ class F33Handler(BaseHandler):
         "graphical": commands.displaymode.F26_DisplayMode,
         "group": commands.group.F12_Group,
         "halt": commands.reboot.F23_Reboot,
-        "harddrive": commands.harddrive.FC3_HardDrive,
+        "harddrive": commands.harddrive.F33_HardDrive,
         "hmc": commands.hmc.F28_Hmc,
         "ignoredisk": commands.ignoredisk.F29_IgnoreDisk,
         "install": commands.install.F29_Install,


### PR DESCRIPTION
It's not supported by Anaconda for a long time. All the Anaconda code was using `biospart` attribute was that it's not yet supported and this code was in Anaconda from 2012. Let's remove this completely and make everything simpler.

See https://github.com/rhinstaller/anaconda/pull/2810


-------------------------
Is there a way how to avoid changing old test case when removing arguments? Did I missed something?