### PR TITLE
Make tmp file creation cross-platform in ksvalidator to support Windows

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -136,7 +136,7 @@ def preprocessFromString(s):
     s = preprocessFromStringToString(s)
     if s:
         import tempfile
-        (outF, outName) = tempfile.mkstemp("-ks.cfg", "", "/tmp")
+        (outF, outName) = tempfile.mkstemp(suffix="-ks.cfg")
 
         os.write(outF, s)
         os.close(outF)
@@ -153,7 +153,7 @@ def preprocessKickstart(f):
     s = preprocessKickstartToString(f)
     if s:
         import tempfile
-        (outF, outName) = tempfile.mkstemp("-ks.cfg", "", "/tmp")
+        (outF, outName) = tempfile.mkstemp(suffix="-ks.cfg")
 
         os.write(outF, s)
         os.close(outF)

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -80,9 +80,9 @@ def main(argv):
     if not opts.ksfile:
         return (1, op.format_usage().split("\n"))
 
-    destdir = tempfile.mkdtemp("", "ksvalidator-tmp-", "/tmp")
+    destdir = tempfile.mkdtemp(prefix="ksvalidator-tmp-")
     try:
-        f = load_to_file(opts.ksfile, "%s/ks.cfg" % destdir)
+        f = load_to_file(opts.ksfile, os.path.join(destdir, "ks.cfg"))
     except KickstartError as e:
         return (cleanup(destdir),
                 [_("Error reading %(filename)s:\n%(version)s") % {"filename": opts.ksfile, "version": e}])


### PR DESCRIPTION
* mkdtemp and mkstemp will determine tmp dir based on runtime OS

I haven't modified tests since there are so many failures on windows (of 486 tests 61 failed, 16 had errors) but they should pass on *nix since [`/tmp` is the first default lookup.](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir)