### PR TITLE
Mark the level option of the logging command as deprecated

### DIFF
--- a/pykickstart/commands/logging.py
+++ b/pykickstart/commands/logging.py
@@ -17,7 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC6
+from pykickstart.version import FC6, F34
 from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
@@ -81,3 +81,24 @@ class FC6_Logging(KickstartCommand):
 
         self._level_provided = True
         return self
+
+
+class F34_Logging(FC6_Logging):
+
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+
+        if self.host:
+            retval += "# Installation logging level\nlogging --host=%s" % self.host
+
+            if self.port:
+                retval += " --port=%s" % self.port
+
+            retval = retval + "\n"
+
+        return retval
+
+    def _getParser(self):
+        op = super()._getParser()
+        op.add_argument("--level", deprecated=F34)
+        return op

--- a/pykickstart/handlers/f34.py
+++ b/pykickstart/handlers/f34.py
@@ -56,7 +56,7 @@ class F34Handler(BaseHandler):
         "keyboard": commands.keyboard.F18_Keyboard,
         "lang": commands.lang.F19_Lang,
         "liveimg": commands.liveimg.F19_Liveimg,
-        "logging": commands.logging.FC6_Logging,
+        "logging": commands.logging.F34_Logging,
         "logvol": commands.logvol.F29_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
         "method": commands.method.F28_Method,

--- a/tests/commands/logging.py
+++ b/tests/commands/logging.py
@@ -20,6 +20,8 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.logging import FC6_Logging
+from pykickstart.errors import KickstartDeprecationWarning
+
 
 class FC6_TestCase(CommandTest):
     command = "logging"
@@ -46,6 +48,34 @@ class FC6_TestCase(CommandTest):
         self.assert_parse_error("logging --host")
         self.assert_parse_error("logging --port")
         self.assert_parse_error("logging --port=PORT")
+
+
+class F34_TestCase(CommandTest):
+    command = "logging"
+
+    def runTest(self):
+        # pass
+        self.assert_parse("logging", "")
+        self.assert_parse("logging --host=HOSTNAME", "logging --host=HOSTNAME\n")
+        self.assert_parse("logging --host=HOSTNAME --port=PORT", "logging --host=HOSTNAME --port=PORT\n")
+
+        # fail
+        self.assert_parse_error("logging --host")
+        self.assert_parse_error("logging --port")
+        self.assert_parse_error("logging --port=PORT")
+
+        # deprecated
+        self.assert_deprecated("logging", "--level")
+
+        with self.assertWarns(KickstartDeprecationWarning):
+            self.assert_parse("logging --level=info", "")
+
+        with self.assertWarns(KickstartDeprecationWarning):
+            self.assert_parse("logging --level=info --host=HOSTNAME", "logging --host=HOSTNAME\n")
+
+        with self.assertWarns(KickstartDeprecationWarning):
+            self.assert_parse("logging --level=info --host=HOSTNAME --port=PORT", "logging --host=HOSTNAME --port=PORT\n")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Anaconda doesn't support changing of a log level for a while now.