### PR TITLE
Deprecate the autostep command

### DIFF
--- a/pykickstart/commands/autostep.py
+++ b/pykickstart/commands/autostep.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3
-from pykickstart.base import KickstartCommand
+from pykickstart.version import FC3, F34, versionToLongString
+from pykickstart.base import KickstartCommand, DeprecatedCommand
 from pykickstart.options import KSOptionParser
 
 class FC3_AutoStep(KickstartCommand):
@@ -64,3 +64,12 @@ class FC3_AutoStep(KickstartCommand):
         self.set_to_self(ns)
         self.autostep = True
         return self
+
+class F34_AutoStep(DeprecatedCommand, FC3_AutoStep):
+    def __init__(self):  # pylint: disable=super-init-not-called
+        DeprecatedCommand.__init__(self)
+
+    def _getParser(self):
+        op = FC3_AutoStep._getParser(self)
+        op.description += "\n\n.. deprecated:: %s" % versionToLongString(F34)
+        return op

--- a/pykickstart/handlers/f34.py
+++ b/pykickstart/handlers/f34.py
@@ -29,7 +29,7 @@ class F34Handler(BaseHandler):
         "authconfig": commands.authconfig.F28_Authconfig,
         "authselect": commands.authselect.F28_Authselect,
         "autopart": commands.autopart.F29_AutoPart,
-        "autostep": commands.autostep.FC3_AutoStep,
+        "autostep": commands.autostep.F34_AutoStep,
         "bootloader": commands.bootloader.F29_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,
         "cdrom": commands.cdrom.FC3_Cdrom,

--- a/tests/commands/autostep.py
+++ b/tests/commands/autostep.py
@@ -20,6 +20,7 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.autostep import FC3_AutoStep
+from pykickstart.base import DeprecatedCommand
 
 class FC3_TestCase(CommandTest):
     command = "autostep"
@@ -31,6 +32,15 @@ class FC3_TestCase(CommandTest):
 
         # fail
         self.assert_parse_error("autostep --autoscreenshot=FOO")
+
+class F34_TestCase(FC3_TestCase):
+    def runTest(self):
+        # make sure we've been deprecated
+        parser = self.getParser("autostep")
+        self.assertTrue(issubclass(parser.__class__, DeprecatedCommand))
+
+        # make sure we are still able to parse it
+        self.assert_parse("autostep")
 
 class AutoStep_TestCase(unittest.TestCase):
     """


### PR DESCRIPTION
It doesn't really work in Anaconda anymore.