### PR TITLE
Deprecate the %traceback section

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -36,7 +36,7 @@ from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACE
                                   KS_BROKEN_IGNORE, KS_BROKEN_REPORT
 from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.options import KSOptionParser
-from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, RHEL6, RHEL7
+from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, F34, RHEL6, RHEL7
 from pykickstart.i18n import _
 
 class Section(object):
@@ -435,6 +435,17 @@ class TracebackScriptSection(OnErrorScriptSection):
     def _resetScript(self):
         OnErrorScriptSection._resetScript(self)
         self._script["type"] = KS_SCRIPT_TRACEBACK
+
+    def handleHeader(self, lineno, args):
+        super().handleHeader(lineno, args)
+
+        if self.version < F34:
+            return
+
+        warnings.warn("The %traceback section has been deprecated. It may be removed in the "
+                      "future, which will result in a fatal error from kickstart. Please modify "
+                      "your kickstart file to use the %onerror section instead.",
+                      KickstartDeprecationWarning)
 
 class PackageSection(Section):
     sectionOpen = "%packages"

--- a/tests/sections.py
+++ b/tests/sections.py
@@ -1,0 +1,28 @@
+import unittest
+import warnings
+
+from tests.baseclass import ParserTest
+
+from pykickstart import sections
+from pykickstart.errors import KickstartDeprecationWarning
+from pykickstart.parser import KickstartParser
+from pykickstart.version import makeVersion, F33, F34
+
+
+class TracebackScriptSection_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = "\n%traceback\n%end\n"
+
+    def runTest(self):
+
+        # F33 has no warnings
+        handler = makeVersion(version=F33)
+        parser = KickstartParser(handler)
+        with warnings.catch_warnings(record=True) as w:
+            parser.readKickstartFromString(self.ks)
+            self.assertEqual(len(w), 0)
+
+        # F34 warns about deprecation
+        with self.assertWarns(KickstartDeprecationWarning):
+            self.parser.readKickstartFromString(self.ks)


### PR DESCRIPTION
It only duplicates the `%onerror` section and exists due to historical reasons.