### PR TITLE
Fix deprecation test for removed commands

### DIFF
--- a/tests/misc.py
+++ b/tests/misc.py
@@ -70,6 +70,8 @@ class DeprecatedCommandsParsing_TestCase(unittest.TestCase):
             for command_name, command_class in command_map.items():
                 if not issubclass(command_class, DeprecatedCommand):
                     continue
+                if issubclass(command_class, RemovedCommand):
+                    continue
 
                 with warnings.catch_warnings(record=True):
                     # The deprecated commands should be ignored with


### PR DESCRIPTION
It's normal to deprecate commands before removing, so usually the final version of a command will be a subclass of *both* `DeprecatedCommand` and `RemovedCommand`.

This failed for me in #364. I think all subsequent `RemovedCommand` usages depend on this.