### PR TITLE
Change old command removals to use RemovedCommand

### DIFF
--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import RHEL5, RHEL6, versionToLongString
 from pykickstart.version import FC3, FC4, F8, F12, F14, F15, F17, F18, F19, F21, F29, F34
-from pykickstart.base import KickstartCommand
+from pykickstart.base import KickstartCommand, RemovedCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
@@ -160,7 +160,12 @@ class FC3_Lilo(FC3_Bootloader):
     def _getParser(self):
         op = super(FC3_Lilo, self)._getParser()
         op.prog = "lilo"
-        op.description += "\n\n.. deprecated:: %s" % versionToLongString(FC4)
+        return op
+
+class FC4_Lilo(RemovedCommand, FC3_Lilo):
+    def _getParser(self):
+        op = FC3_Lilo._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(FC4)
         return op
 
 

--- a/pykickstart/commands/interactive.py
+++ b/pykickstart/commands/interactive.py
@@ -57,7 +57,7 @@ class F14_Interactive(DeprecatedCommand, FC3_Interactive):
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(F14)
         return op
 
-class F15_Interactive(RemovedCommand):
+class F15_Interactive(RemovedCommand, F14_Interactive):
     def _getParser(self):
         op = F14_Interactive._getParser(self)
         op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F15)

--- a/pykickstart/commands/langsupport.py
+++ b/pykickstart/commands/langsupport.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, FC5, versionToLongString
-from pykickstart.base import DeprecatedCommand, KickstartCommand
+from pykickstart.version import FC3, FC5, F7, versionToLongString
+from pykickstart.base import DeprecatedCommand, KickstartCommand, RemovedCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.i18n import _
 from pykickstart.options import KSOptionParser
@@ -69,4 +69,10 @@ class FC5_LangSupport(DeprecatedCommand, FC3_LangSupport):
     def _getParser(self):
         op = FC3_LangSupport._getParser(self)
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(FC5)
+        return op
+
+class F7_LangSupport(RemovedCommand, FC5_LangSupport):
+    def _getParser(self):
+        op = FC5_LangSupport._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F7)
         return op

--- a/pykickstart/commands/lilocheck.py
+++ b/pykickstart/commands/lilocheck.py
@@ -18,7 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 from pykickstart.version import FC3, FC4, versionToLongString
-from pykickstart.base import KickstartCommand
+from pykickstart.base import KickstartCommand, RemovedCommand
 from pykickstart.options import KSOptionParser
 
 class FC3_LiloCheck(KickstartCommand):
@@ -40,10 +40,15 @@ class FC3_LiloCheck(KickstartCommand):
 
     def _getParser(self):
         op = KSOptionParser(prog="lilocheck", description="check LILO boot loader", version=FC3)
-        op.description += "\n\n.. deprecated:: %s" % versionToLongString(FC4)
         return op
 
     def parse(self, args):
         self.op.parse_args(args=args, lineno=self.lineno)
         self.check = True
         return self
+
+class FC4_LiloCheck(RemovedCommand, FC3_LiloCheck):
+    def _getParser(self):
+        op = FC3_LiloCheck._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(FC4)
+        return op

--- a/pykickstart/commands/monitor.py
+++ b/pykickstart/commands/monitor.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, FC6, F10, versionToLongString
-from pykickstart.base import DeprecatedCommand, KickstartCommand
+from pykickstart.version import FC3, FC6, F10, F18, versionToLongString
+from pykickstart.base import DeprecatedCommand, KickstartCommand, RemovedCommand
 from pykickstart.options import KSOptionParser
 
 class FC3_Monitor(KickstartCommand):
@@ -115,4 +115,10 @@ class F10_Monitor(DeprecatedCommand, FC6_Monitor):
     def _getParser(self):
         op = FC6_Monitor._getParser(self)
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(F10)
+        return op
+
+class F18_Monitor(RemovedCommand, F10_Monitor):
+    def _getParser(self):
+        op = F10_Monitor._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F18)
         return op

--- a/pykickstart/commands/mouse.py
+++ b/pykickstart/commands/mouse.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import versionToLongString, RHEL3, FC3
-from pykickstart.base import DeprecatedCommand, KickstartCommand
+from pykickstart.version import versionToLongString, RHEL3, FC3, F7
+from pykickstart.base import DeprecatedCommand, KickstartCommand, RemovedCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
@@ -78,4 +78,10 @@ class FC3_Mouse(DeprecatedCommand, RHEL3_Mouse):
     def _getParser(self):
         op = RHEL3_Mouse._getParser(self)
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(FC3)
+        return op
+
+class F7_Mouse(RemovedCommand, FC3_Mouse):
+    def _getParser(self):
+        op = FC3_Mouse._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F7)
         return op

--- a/pykickstart/commands/upgrade.py
+++ b/pykickstart/commands/upgrade.py
@@ -18,8 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 from textwrap import dedent
-from pykickstart.version import versionToLongString, FC3, F11, F20
-from pykickstart.base import DeprecatedCommand, KickstartCommand
+from pykickstart.version import versionToLongString, FC3, F11, F20, F29
+from pykickstart.base import DeprecatedCommand, KickstartCommand, RemovedCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
@@ -127,4 +127,10 @@ class F20_Upgrade(DeprecatedCommand, F11_Upgrade):
                         tool. Starting with F21, the DNF system-upgrade plugin is
                         recommended instead.  Therefore, the upgrade command
                         essentially does nothing.""" % versionToLongString(F20))
+        return op
+
+class F29_Upgrade(RemovedCommand, F20_Upgrade):
+    def _getParser(self):
+        op = F20_Upgrade._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F29)
         return op

--- a/pykickstart/handlers/f18.py
+++ b/pykickstart/handlers/f18.py
@@ -57,6 +57,7 @@ class F18Handler(BaseHandler):
         "logvol": commands.logvol.F18_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
         "method": commands.method.F18_Method,
+        "monitor": commands.monitor.F18_Monitor,  # RemovedCommand
         "multipath": commands.multipath.FC6_MultiPath,
         "network": commands.network.F18_Network,
         "nfs": commands.nfs.FC6_NFS,

--- a/pykickstart/handlers/f29.py
+++ b/pykickstart/handlers/f29.py
@@ -88,6 +88,7 @@ class F29Handler(BaseHandler):
         "text": commands.displaymode.F26_DisplayMode,
         "timezone": commands.timezone.F25_Timezone,
         "updates": commands.updates.F7_Updates,
+        "upgrade": commands.upgrade.F29_Upgrade,  # RemovedCommand
         "url": commands.url.F27_Url,
         "user": commands.user.F24_User,
         "vnc": commands.vnc.F9_Vnc,

--- a/pykickstart/handlers/f7.py
+++ b/pykickstart/handlers/f7.py
@@ -56,6 +56,7 @@ class F7Handler(BaseHandler):
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
         "method": commands.method.FC6_Method,
         "monitor": commands.monitor.FC6_Monitor,
+        "mouse": commands.mouse.F7_Mouse,  # RemovedCommand
         "multipath": commands.multipath.FC6_MultiPath,
         "network": commands.network.FC6_Network,
         "nfs": commands.nfs.FC6_NFS,

--- a/pykickstart/handlers/f7.py
+++ b/pykickstart/handlers/f7.py
@@ -51,6 +51,7 @@ class F7Handler(BaseHandler):
         "iscsiname": commands.iscsiname.FC6_IscsiName,
         "keyboard": commands.keyboard.FC3_Keyboard,
         "lang": commands.lang.FC3_Lang,
+        "langsupport": commands.langsupport.F7_LangSupport,  # RemovedCommand
         "logging": commands.logging.FC6_Logging,
         "logvol": commands.logvol.FC4_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,

--- a/pykickstart/handlers/fc4.py
+++ b/pykickstart/handlers/fc4.py
@@ -49,6 +49,7 @@ class FC4Handler(BaseHandler):
         "keyboard": commands.keyboard.FC3_Keyboard,
         "lang": commands.lang.FC3_Lang,
         "langsupport": commands.langsupport.FC3_LangSupport,
+        "lilocheck": commands.lilocheck.FC4_LiloCheck,  # RemovedCommand
         "logvol": commands.logvol.FC4_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
         "method": commands.method.FC3_Method,

--- a/pykickstart/handlers/fc4.py
+++ b/pykickstart/handlers/fc4.py
@@ -49,6 +49,7 @@ class FC4Handler(BaseHandler):
         "keyboard": commands.keyboard.FC3_Keyboard,
         "lang": commands.lang.FC3_Lang,
         "langsupport": commands.langsupport.FC3_LangSupport,
+        "lilo": commands.bootloader.FC4_Lilo,  # RemovedCommand
         "lilocheck": commands.lilocheck.FC4_LiloCheck,  # RemovedCommand
         "logvol": commands.logvol.FC4_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,

--- a/tests/commands/bootloader.py
+++ b/tests/commands/bootloader.py
@@ -20,6 +20,7 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.errors import KickstartDeprecationWarning
+from pykickstart.base import RemovedCommand
 
 class FC3_TestCase(CommandTest):
     command = "bootloader"
@@ -80,6 +81,12 @@ class FC4_TestCase(FC3_TestCase):
         self.assert_removed("bootloader", "--linear")
         self.assert_removed("bootloader", "--nolinear")
         self.assert_removed("bootloader", "--useLilo")
+
+class FC4_Lilo_TestCase(CommandTest):
+    def runTest(self):
+        # make sure that lilo is removed
+        cmd = self.handler().commands["lilo"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 class F8_TestCase(FC4_TestCase):
     def runTest(self, iscrypted=False):

--- a/tests/commands/interactive.py
+++ b/tests/commands/interactive.py
@@ -18,7 +18,7 @@
 #
 import unittest
 from tests.baseclass import CommandTest
-from pykickstart.base import DeprecatedCommand
+from pykickstart.base import DeprecatedCommand, RemovedCommand
 from pykickstart.commands.interactive import FC3_Interactive
 
 class FC3_TestCase(CommandTest):
@@ -44,6 +44,12 @@ class F14_TestCase(FC3_TestCase):
         # make sure we've been deprecated
         parser = self.getParser("interactive")
         self.assertEqual(issubclass(parser.__class__, DeprecatedCommand), True)
+
+class F15_TestCase(F14_TestCase):
+    def runTest(self):
+        # make sure that interactive is removed
+        cmd = self.handler().commands["interactive"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 class Interactive_TestCase(unittest.TestCase):
     def runTest(self):

--- a/tests/commands/langsupport.py
+++ b/tests/commands/langsupport.py
@@ -20,6 +20,7 @@
 
 import unittest
 from tests.baseclass import CommandTest
+from pykickstart.base import RemovedCommand
 
 class FC3_TestCase(CommandTest):
     command = "langsupport"
@@ -41,6 +42,12 @@ class FC3_TestCase(CommandTest):
         cmd = self.handler().commands[self.command]
         cmd.deflang = None
         self.assertEqual(cmd.__str__(), "\n")
+
+class F7_TestCase(CommandTest):
+    def runTest(self):
+        # make sure that langsupport is removed
+        cmd = self.handler().commands["langsupport"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/lilocheck.py
+++ b/tests/commands/lilocheck.py
@@ -21,6 +21,7 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.lilocheck import FC3_LiloCheck
+from pykickstart.base import RemovedCommand
 
 class FC3_TestCase(CommandTest):
     command = "lilocheck"
@@ -37,6 +38,12 @@ class FC3_TestCase(CommandTest):
         cmd = self.handler().commands[self.command]
         cmd.check = False
         self.assertEqual(cmd.__str__(), "")
+
+class FC4_TestCase(CommandTest):
+    def runTest(self):
+        # make sure that lilocheck is removed
+        cmd = self.handler().commands["lilocheck"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 class LiloCheck_TestCase(unittest.TestCase):
     def runTest(self):

--- a/tests/commands/monitor.py
+++ b/tests/commands/monitor.py
@@ -20,7 +20,7 @@
 import unittest
 
 from tests.baseclass import CommandTest
-from pykickstart.base import DeprecatedCommand
+from pykickstart.base import DeprecatedCommand, RemovedCommand
 from pykickstart.commands.monitor import FC6_Monitor
 
 class FC3_TestCase(CommandTest):
@@ -65,6 +65,12 @@ class F10_TestCase(FC6_TestCase):
         parser = parser._getParser()
         self.assertIsNotNone(parser)
         self.assertTrue(parser.description.find('deprecated:: Fedora10') > -1)
+
+class F18_TestCase(F10_TestCase):
+    def runTest(self):
+        # make sure that monitor is removed
+        cmd = self.handler().commands["monitor"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/mouse.py
+++ b/tests/commands/mouse.py
@@ -21,6 +21,7 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.mouse import RHEL3_Mouse
+from pykickstart.base import RemovedCommand
 
 class Mouse_TestCase(unittest.TestCase):
     def runTest(self):
@@ -52,6 +53,12 @@ class RHEL3_TestCase(CommandTest):
         cmd = self.handler().commands[self.command]
         cmd.mouse = False
         self.assertEqual(cmd.__str__(), "")
+
+class F7_Mouse_TestCase(CommandTest):
+    def runTest(self):
+        # make sure that mouse is removed
+        cmd = self.handler().commands["mouse"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/upgrade.py
+++ b/tests/commands/upgrade.py
@@ -21,7 +21,7 @@
 import unittest
 import warnings
 from tests.baseclass import CommandTest
-from pykickstart.base import DeprecatedCommand
+from pykickstart.base import DeprecatedCommand, RemovedCommand
 from pykickstart.commands.upgrade import FC3_Upgrade
 
 class Upgrade_TestCase(unittest.TestCase):
@@ -80,10 +80,13 @@ class F20_TestCase(F11_TestCase):
 class F29_TestCase(F20_TestCase):
     def runTest(self):
         # make sure that upgrade is removed
-        self.assertNotIn("upgrade", self.handler().commands)
+        cmd = self.handler().commands["upgrade"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
-class RHEL8_TestCase(F29_TestCase):
-    pass
+class RHEL8_TestCase(F20_TestCase):
+    def runTest(self):
+        # make sure that upgrade is removed
+        self.assertNotIn("upgrade", self.handler().commands)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ksverdiff.py
+++ b/tools/ksverdiff.py
@@ -71,11 +71,15 @@ def main(argv=None):
     bothSet = fromCmdSet & toCmdSet
 
     print(_("The following commands were removed in %s:") % opts.t)
-    removed = [cmd for cmd in bothSet if isinstance(toHandler.commands[cmd], RemovedCommand)]
+    removed = [cmd for cmd in bothSet if
+               isinstance(toHandler.commands[cmd], RemovedCommand) and
+               not isinstance(fromHandler.commands[cmd], RemovedCommand)]
     printList(sorted(removed + list(fromCmdSet - toCmdSet)))
 
     print(_("The following commands were deprecated in %s:") % opts.t)
-    printList(sorted([cmd for cmd in bothSet if isinstance(toHandler.commands[cmd], DeprecatedCommand)]))
+    printList(sorted([cmd for cmd in bothSet if
+                      isinstance(toHandler.commands[cmd], DeprecatedCommand) and
+                      not isinstance(toHandler.commands[cmd], RemovedCommand)]))
 
     print(_("The following commands were added in %s:") % opts.t)
     printList(sorted(toCmdSet - fromCmdSet))


### PR DESCRIPTION
This should make all removals conform to The New Way™.

Most of this is straightforward, but the lilo-related commits needed making choices about how to classify deprecated/removed.