### PR TITLE
Conditionally BuildRequire coverage and sphinx for runtests

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -15,12 +15,17 @@ Source1:   https://github.com/pykickstart/%{name}/releases/download/r%{version}/
 BuildArch: noarch
 
 BuildRequires: gettext
-BuildRequires: python3-coverage
 BuildRequires: python3-devel
 BuildRequires: python3-requests
 BuildRequires: python3-setuptools
 BuildRequires: python3-six
+BuildRequires: make
+
+# Only required when building with runtests
+%if %{with runtests}
+BuildRequires: python3-coverage
 BuildRequires: python3-sphinx
+%endif
 
 Requires: python3-kickstart = %{version}-%{release}
 


### PR DESCRIPTION
They aren't needed for the build unless runtests has been selected (it
is disabled by default).

Resolves: rhbz#1916735