### PR TITLE
Add F34_MountData that enforces compression on btrfs (#1928857)

### DIFF
--- a/pykickstart/commands/mount.py
+++ b/pykickstart/commands/mount.py
@@ -25,6 +25,7 @@ from pykickstart.version import F27
 
 from pykickstart.i18n import _
 
+
 class F27_MountData(BaseData):
     removedKeywords = BaseData.removedKeywords
     removedAttrs = BaseData.removedAttrs
@@ -69,6 +70,19 @@ class F27_MountData(BaseData):
         retval = BaseData.__str__(self)
         retval += "mount %s\n" % self._getArgsAsStr()
         return retval
+
+
+class F34_MountData(F27_MountData):
+    removedKeywords = F27_MountData.removedKeywords
+    removedAttrs = F27_MountData.removedAttrs
+
+    def __init__(self, *args, **kwargs):
+        F27_MountData.__init__(self, *args, **kwargs)
+        if self.format == "btrfs":
+            if not "compress" in self.mount_opts:
+                opts = set(self.mount_opts.split(","))
+                opts.add("compress=zstd:1")
+                self.mount_opts = ",".join(opts)
 
 
 class F27_Mount(KickstartCommand):

--- a/pykickstart/handlers/f34.py
+++ b/pykickstart/handlers/f34.py
@@ -108,7 +108,7 @@ class F34Handler(BaseHandler):
         "GroupData": commands.group.F12_GroupData,
         "IscsiData": commands.iscsi.F17_IscsiData,
         "LogVolData": commands.logvol.F29_LogVolData,
-        "MountData": commands.mount.F27_MountData,
+        "MountData": commands.mount.F34_MountData,
         "MultiPathData": commands.multipath.FC6_MultiPathData,
         "NetworkData": commands.network.F27_NetworkData,
         "NvdimmData": commands.nvdimm.F28_NvdimmData,


### PR DESCRIPTION
On F34, we want to ensure that Btrfs filesystems are mounted with
transparent compression enabled; the compression algorithm and
level decided on was `compress=zstd:1`.

Ensure `MountData` always return this unless a different compression
setting is selected.

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pykickstart/pykickstart/373)
<!-- Reviewable:end -->
