### PR TITLE
Remove python six library

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -18,7 +18,6 @@ BuildRequires: gettext
 BuildRequires: python3-devel
 BuildRequires: python3-requests
 BuildRequires: python3-setuptools
-BuildRequires: python3-six
 BuildRequires: make
 
 # Only required when building with runtests
@@ -34,7 +33,6 @@ Python utilities for manipulating kickstart files.
 
 %package -n python3-kickstart
 Summary:  Python 3 library for manipulating kickstart files.
-Requires: python3-six
 Requires: python3-requests
 
 %description -n python3-kickstart

--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -45,7 +45,6 @@ This module exports several important base classes:
 """
 from pykickstart.i18n import _
 
-import six
 import warnings
 from pykickstart import __version__
 from pykickstart.errors import KickstartParseError, KickstartParseWarning, KickstartDeprecationWarning
@@ -300,10 +299,7 @@ class KickstartHandler(KickstartObject):
 
         for prio in lst:
             for obj in self._writeOrder[prio]:
-                obj_str = obj.__str__()
-                if isinstance(obj_str, six.text_type) and not six.PY3:
-                    obj_str = obj_str.encode("utf-8")
-                retval += obj_str
+                retval += obj.__str__()
 
         return retval
 
@@ -334,12 +330,8 @@ class KickstartHandler(KickstartObject):
         # off the version part from the front of the name.
         if cmdObj.__class__.__name__.find("_") != -1:
             name = cmdObj.__class__.__name__.split("_", 1)[1]
-            if not six.PY3:
-                name = unicode(name)    # pylint: disable=undefined-variable
         else:
             name = cmdObj.__class__.__name__.lower()
-            if not six.PY3:
-                name = unicode(name)    # pylint: disable=undefined-variable
 
         setattr(self, name.lower(), cmdObj)
 
@@ -505,10 +497,7 @@ class BaseHandler(KickstartHandler):
         retval += KickstartHandler.__str__(self)
 
         for script in self.scripts:
-            script_str = script.__str__()
-            if isinstance(script_str, six.text_type) and not six.PY3:
-                script_str = script_str.encode("utf-8")
-            retval += script_str
+            retval += script.__str__()
 
         if self._null_section_strings:
             retval += "\n"

--- a/pykickstart/commands/rootpw.py
+++ b/pykickstart/commands/rootpw.py
@@ -24,7 +24,6 @@ from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
 
-import six
 
 class FC3_RootPw(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -49,9 +48,7 @@ class FC3_RootPw(KickstartCommand):
         retval = KickstartCommand.__str__(self)
 
         if self.password:
-            if isinstance(self.password, six.binary_type) and b'#' in self.password:
-                password = '\"' + self.password + '\"'
-            elif not isinstance(self.password, six.binary_type) and u'#' in self.password:
+            if '#' in self.password:
                 password = '\"' + self.password + '\"'
             else:
                 password = self.password

--- a/pykickstart/commands/user.py
+++ b/pykickstart/commands/user.py
@@ -23,7 +23,6 @@ from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser, commaSplit
 
 import warnings
-import six
 from pykickstart.i18n import _
 
 class FC6_UserData(BaseData):
@@ -68,9 +67,7 @@ class FC6_UserData(BaseData):
         if self.name:
             retval += " --name=%s" % self.name
         if self.password:
-            if isinstance(self.password, six.binary_type) and b'#' in self.password:
-                retval += " --password=\"%s\"" % self.password
-            elif not isinstance(self.password, six.binary_type) and u'#' in self.password:
+            if '#' in self.password:
                 retval += " --password=\"%s\"" % self.password
             else:
                 retval += " --password=%s" % self.password

--- a/pykickstart/i18n.py
+++ b/pykickstart/i18n.py
@@ -19,7 +19,6 @@
 #
 import gettext
 import os
-import six
 
 def _find_locale_files():
     module_path = os.path.abspath(__file__)
@@ -29,7 +28,4 @@ def _find_locale_files():
     gettext.textdomain("pykickstart")
 _find_locale_files()
 
-if six.PY3:
-    _ = lambda x: gettext.gettext(x) if x else ''
-else:
-    _ = lambda x: gettext.lgettext(x) if x else ''
+_ = lambda x: gettext.gettext(x) if x else ''

--- a/pykickstart/load.py
+++ b/pykickstart/load.py
@@ -19,7 +19,6 @@
 #
 import requests
 import shutil
-import six
 
 from pykickstart.errors import KickstartError
 from pykickstart.i18n import _
@@ -89,12 +88,8 @@ def _load_file(filename):
     '''Load a file's contents and return them as a string'''
 
     try:
-        if six.PY3:
-            with open(filename, 'rb') as fh:
-                contents = fh.read().decode("utf-8")
-        else:
-            with open(filename, 'r') as fh:
-                contents = fh.read()
+        with open(filename, 'rb') as fh:
+            contents = fh.read().decode("utf-8")
     except IOError as e:
         raise KickstartError(_('Error opening file: %s') % str(e))
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -39,7 +39,6 @@ except ImportError:  # python2 compatibility
     from collections import Iterator
 
 import os
-import six
 import shlex
 import sys
 import warnings
@@ -63,8 +62,7 @@ def _preprocessStateMachine(lineIter):
     lineno = 0
     retval = ""
 
-    if six.PY3:
-        retval = retval.encode(sys.getdefaultencoding())
+    retval = retval.encode(sys.getdefaultencoding())
 
     while True:
         try:
@@ -81,9 +79,7 @@ def _preprocessStateMachine(lineIter):
 
         ll = l.strip()
         if not ll.startswith("%ksappend"):
-            if six.PY3:
-                l = l.encode(sys.getdefaultencoding())
-            retval += l
+            retval += l.encode(sys.getdefaultencoding())
             continue
 
         # Try to pull down the remote file.

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(cmdclass={"install_scripts": install_scripts},
       description='Python module for manipulating kickstart files',
       author='Chris Lumens', author_email='clumens@redhat.com',
       url='http://fedoraproject.org/wiki/pykickstart',
-      install_requires=['six', 'requests'],
+      install_requires=['requests'],
       extras_require={
           "docs": ['Sphinx'],
           "test": ['coveralls', 'coverage', 'pocketlint', 'pylint']},

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -5,7 +5,6 @@ import shlex
 import glob
 import warnings
 import re
-import six
 
 import importlib
 
@@ -59,7 +58,7 @@ class ParserTest(unittest.TestCase):
         By default the KickstartParseError is expected.
         """
 
-        with six.assertRaisesRegex(self, exception, regex):
+        with self.assertRaisesRegex(exception, regex):
             self.parser.readKickstartFromString(ks_string)
 
     def assert_parse(self, ks_string):
@@ -187,7 +186,7 @@ class CommandTest(unittest.TestCase):
         parser = self.getParser(inputStr)
         args = shlex.split(inputStr, comments=True)
 
-        with six.assertRaisesRegex(self, exception, regex):
+        with self.assertRaisesRegex(exception, regex):
             parser.parse(args[1:])
 
     def assert_deprecated(self, cmd, opt):

--- a/tests/commands/logvol.py
+++ b/tests/commands/logvol.py
@@ -1,4 +1,3 @@
-import six
 import unittest
 
 from pykickstart.errors import KickstartParseWarning
@@ -8,10 +7,7 @@ from pykickstart.commands.logvol import FC3_LogVolData, F9_LogVolData, F12_LogVo
 from pykickstart.errors import KickstartParseError
 from pykickstart.version import FC3, RHEL6, F20
 
-if six.PY3:
-    requiredError = "arguments are required: %s"
-else:
-    requiredError = "argument %s is required"
+requiredError = "arguments are required: %s"
 
 class LogVol_TestCase(unittest.TestCase):
     def runTest(self):
@@ -132,16 +128,10 @@ class FC3_TestCase(CommandTest):
         self.assert_parse_error("logvol / --vgname=NAME", regex=requiredError % "--name")
 
         # fail - missing a mountpoint
-        if six.PY3:
-            self.assert_parse_error("logvol", regex=requiredError % "<mntpoint>, --name, --vgname")
-            self.assert_parse_error("logvol --name=NAME", regex=requiredError % "<mntpoint>, --vgname")
-            self.assert_parse_error("logvol --vgname=NAME", regex=requiredError % "<mntpoint>, --name")
-            self.assert_parse_error("logvol --name=NAME --vgname=NAME", regex=requiredError % "<mntpoint>")
-        else:
-            self.assert_parse_error("logvol", regex="too few arguments")
-            self.assert_parse_error("logvol --name=NAME", regex="too few arguments")
-            self.assert_parse_error("logvol --vgname=NAME", regex="too few arguments")
-            self.assert_parse_error("logvol --name=NAME --vgname=NAME", regex="too few arguments")
+        self.assert_parse_error("logvol", regex=requiredError % "<mntpoint>, --name, --vgname")
+        self.assert_parse_error("logvol --name=NAME", regex=requiredError % "<mntpoint>, --vgname")
+        self.assert_parse_error("logvol --vgname=NAME", regex=requiredError % "<mntpoint>, --name")
+        self.assert_parse_error("logvol --name=NAME --vgname=NAME", regex=requiredError % "<mntpoint>")
 
         # fail - unknown options
         self.assert_parse_error("logvol / --name=NAME --vgname=VGNAME --bogus-option")

--- a/tests/handle_unicode.py
+++ b/tests/handle_unicode.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import six
 import unittest
 import tempfile
 import locale
@@ -18,12 +17,6 @@ echo áááááá
 %end
 """
 
-    def get_encoded_str(self, string, force_encode=False):
-        if force_encode or not six.PY3:
-            return string.encode("utf-8")
-        else:
-            return string
-
     def runTest(self):
         unicode_str1 = u"ááááááááá"
         unicode_str2 = u"áááááá"
@@ -40,28 +33,25 @@ echo áááááá
         # original non-ascii strings as utf-8 encoded byte strings and
         # str(self.handler) should not fail -- i.e. self.handler.__str__()
         # should return byte string not unicode string
-        self.assertIn(self.get_encoded_str(unicode_str1), str(self.handler))
-        self.assertIn(self.get_encoded_str(unicode_str2), str(self.handler))
+        self.assertIn(unicode_str1, str(self.handler))
+        self.assertIn(unicode_str2, str(self.handler))
 
         # set root password to unicode string
         self.handler.rootpw.password = unicode_str1
 
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
-        self.assertIn(self.get_encoded_str(unicode_str1), str(self.handler))
+        self.assertIn(unicode_str1, str(self.handler))
 
         # set root password to encoded string
-        self.handler.rootpw.password = self.get_encoded_str(unicode_str1, force_encode=True)
+        self.handler.rootpw.password = unicode_str1
 
         # str(handler) should not cause traceback and should contain the
         # original unicode string as utf-8 encoded byte string
-        self.assertIn(str(self.get_encoded_str(unicode_str1, force_encode=True)), str(self.handler))
+        self.assertIn(str(unicode_str1), str(self.handler))
 
         (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp", text=True)
-        if six.PY3:
-            buf = self.ks.encode("utf-8")
-        else:
-            buf = self.ks
+        buf = self.ks.encode("utf-8")
         os.write(fd, buf)
         os.close(fd)
 
@@ -73,11 +63,7 @@ echo áááááá
             # original non-ascii strings as utf-8 encoded byte strings and
             # str(self.handler) should not fail -- i.e. self.handler.__str__()
             # should return byte string not unicode string
-            self.assertIn(self.get_encoded_str(unicode_str1), str(self.handler))
-            self.assertIn(self.get_encoded_str(unicode_str2), str(self.handler))
+            self.assertIn(unicode_str1, str(self.handler))
+            self.assertIn(unicode_str2, str(self.handler))
         finally:
             os.unlink(name)
-
-if __name__ == "__main__":
-    if not six.PY3:
-        unittest.main()

--- a/tests/include.py
+++ b/tests/include.py
@@ -1,5 +1,5 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 import os
-import six
 import unittest
 import tempfile
 from tests.baseclass import ParserTest
@@ -16,9 +16,7 @@ class Base_Include(ParserTest):
         ParserTest.setUp(self)
 
         (handle, self._path) = tempfile.mkstemp(prefix="include-", text=True)
-        ks = self.includeKS
-        if six.PY3:
-            ks = ks.encode('utf-8')
+        ks = self.includeKS.encode('utf-8')
 
         os.write(handle, ks)
         os.close(handle)
@@ -189,13 +187,13 @@ ls /tmp
         super(Include_URL_TestCase, self).setUp()
 
         # Disable logging in the handler, mostly to keep the HTTPS binary garbage off the screen
-        httphandler = six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler
+        httphandler = SimpleHTTPRequestHandler
 
         def shutup(*args, **kwargs):
             pass
         httphandler.log_message = shutup
 
-        self._server = six.moves.BaseHTTPServer.HTTPServer(('127.0.0.1', 0), httphandler)
+        self._server = HTTPServer(('127.0.0.1', 0), httphandler)
         httpd_port = self._server.server_port
         self._httpd_pid = os.fork()
         if self._httpd_pid == 0:
@@ -222,7 +220,7 @@ ls /tmp
 class Include_Bad_URL_TestCase(Include_URL_TestCase):
     def runTest(self):
         # Add some garbage to the end of the URL and ensure it breaks
-        six.assertRaisesRegex(self, KickstartError, "Error accessing URL",
+        self.assertRaisesRegex(KickstartError, "Error accessing URL",
                               self.parser.readKickstartFromString, self.ks % (self._url + "-garbage"))
 
 if __name__ == "__main__":

--- a/tests/load.py
+++ b/tests/load.py
@@ -1,7 +1,7 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 import unittest
 import os
 import tempfile
-import six
 
 from pykickstart import load
 from pykickstart.errors import KickstartError
@@ -74,13 +74,13 @@ class Load_From_URL_Test(LoadTest):
         super(Load_From_URL_Test, self).setUp()
 
         # Disable logging in the handler, mostly to keep the HTTPS binary garbage off the screen
-        httphandler = six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler
+        httphandler = SimpleHTTPRequestHandler
 
         def shutup(*args, **kwargs):
             pass
         httphandler.log_message = shutup
 
-        self._server = six.moves.BaseHTTPServer.HTTPServer(('127.0.0.1', 0), httphandler)
+        self._server = HTTPServer(('127.0.0.1', 0), httphandler)
         httpd_port = self._server.server_port
         self._httpd_pid = os.fork()
         if self._httpd_pid == 0:

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -1,5 +1,4 @@
 import os
-import six
 import tempfile
 from tests.baseclass import ParserTest
 
@@ -24,9 +23,7 @@ autopart
         self._processedPath = None
 
         (handle, self._path) = tempfile.mkstemp(prefix="ks-", text=True)
-        s = self.ks
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = self.ks.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -73,9 +70,7 @@ timezone America/New_York
         self._processedPath = None
 
         (handle, self._ksappendPath) = tempfile.mkstemp(prefix="ksappend-", text=True)
-        s = self.ksappend
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = self.ksappend.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -84,8 +79,7 @@ timezone America/New_York
         # %ksappend line.
         (handle, self._path) = tempfile.mkstemp(prefix="ks-", text=True)
         s = self.ks + "%ksappend " + self._ksappendPath
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = s.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -171,9 +165,7 @@ timezone America/New_York
         self._path = None
 
         (handle, self._ksappendPath) = tempfile.mkstemp(prefix="ksappend-", text=True)
-        s = self.ksappend
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = self.ksappend.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -206,9 +198,7 @@ autopart
         ParserTest.setUp(self)
 
         (handle, self._path) = tempfile.mkstemp(prefix="ks-", text=True)
-        s = self.ks
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = self.ks.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -255,9 +245,7 @@ timezone America/New_York
         ParserTest.setUp(self)
 
         (handle, self._ksappendPath) = tempfile.mkstemp(prefix="ksappend-", text=True)
-        s = self.ksappend
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = self.ksappend.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -266,8 +254,7 @@ timezone America/New_York
         # %ksappend line.
         (handle, self._path) = tempfile.mkstemp(prefix="ks-", text=True)
         s = self.ks + "%ksappend " + self._ksappendPath
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = s.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)
@@ -328,9 +315,7 @@ timezone America/New_York
         ParserTest.setUp(self)
 
         (handle, self._ksappendPath) = tempfile.mkstemp(prefix="ksappend-", text=True)
-        s = self.ksappend
-        if six.PY3:
-            s = s.encode('utf-8')
+        s = self.ksappend.encode('utf-8')
 
         os.write(handle, s)
         os.close(handle)

--- a/tests/version.py
+++ b/tests/version.py
@@ -1,4 +1,3 @@
-import six
 import sys
 import unittest
 import tempfile
@@ -295,8 +294,7 @@ class versionFromFile_TestCase(CommandTest):
 
         def write_ks_cfg(buf):
             (fd, name) = tempfile.mkstemp(prefix="ks-", suffix=".cfg", dir="/tmp", text=True)
-            if six.PY3:
-                buf = buf.encode(sys.getdefaultencoding())
+            buf = buf.encode(sys.getdefaultencoding())
             os.write(fd, buf)
             os.close(fd)
             return name

--- a/tools/ksshell.py
+++ b/tools/ksshell.py
@@ -37,7 +37,8 @@
 
 import readline
 import argparse
-import os, six, sys
+import os
+import sys
 
 from pykickstart.i18n import _
 from pykickstart.errors import KickstartError, KickstartVersionError
@@ -202,7 +203,7 @@ def main(argv=None):
 
     while True:
         try:
-            line = six.moves.input("ks> ")  # pylint: disable=no-member
+            line = input("ks> ")
         except EOFError:
             # ^D was hit, time to quit.
             break


### PR DESCRIPTION
This was necessary when transitioning from Python 2 to 3, but now that
pykickstart is Python 3 only it is just extra code that is unneeded.