### PR TITLE
Update kickstart-docs.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    Kickstart documentation <kickstart-docs>
+   Kickstart examples <kickstart-examples>
    Testing pykickstart <testing>
 
 Indices and tables

--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -160,31 +160,7 @@ machines where the disk configuration is consistent, consider the following:
 - If the configuration has multiple disks, each of which are the same size, you
   can use the device node names as it doesn't matter which disk is which.
 - If you have different size disks, it may be helpful to select the disk based
-  on size.  An example ``%pre`` section which does this:
-
-::
-
-
-    # Partition information is created during install using the %pre section
-    %pre --interpreter /bin/bash --log /tmp/ks_pre.log
-
-        # Dump whole SCSI/IDE disks out sorted from smallest to largest
-        # ouputting just the name
-        disks=(`lsblk -n -o NAME -l -b -x SIZE -d -I 8,3`) || exit 1
-
-        # We are assuming we have 3 disks which will be used
-        # and we will create some variables to represent
-        d0=${disks[0]}
-        d1=${disks[1]}
-        d2=${disks[2]}
-
-        echo "part /home --fstype="xfs" --ondisk=$d2 --grow" >> /tmp/disks
-        echo "part swap --fstype="swap" --ondisk=$d0 --size=4096" >> /tmp/disks
-        echo "part / --fstype="xfs" --ondisk=$d1 --grow" >> /tmp/disks
-        echo "part /boot --fstype="xfs" --ondisk=$d1 --size=1024" >> /tmp/disks
-    %end
-
-Leverage ``%include /tmp/disks`` in the kickstart file to utilize.
+  on size, see: :ref:`kickstart-examples`.
 
 Chapter 2. Kickstart Commands in Fedora
 =======================================

--- a/docs/kickstart-examples.rst
+++ b/docs/kickstart-examples.rst
@@ -1,0 +1,34 @@
+
+.. _kickstart-examples:
+
+Kickstart Examples
+************************
+
+Selecting disks by size
+==========================
+
+An example ``%pre`` section which selects disks by size.
+
+::
+
+    # Partition information is created during install using the %pre section
+    %pre --interpreter /bin/bash --log /tmp/ks_pre.log
+
+        # Dump whole SCSI/IDE disks out sorted from smallest to largest
+        # ouputting just the name
+        disks=(`lsblk -n -o NAME -l -b -x SIZE -d -I 8,3`) || exit 1
+
+        # We are assuming we have 3 disks which will be used
+        # and we will create some variables to represent
+        d0=${disks[0]}
+        d1=${disks[1]}
+        d2=${disks[2]}
+
+        echo "part /home --fstype="xfs" --ondisk=$d2 --grow" >> /tmp/disks
+        echo "part swap --fstype="swap" --ondisk=$d0 --size=4096" >> /tmp/disks
+        echo "part / --fstype="xfs" --ondisk=$d1 --grow" >> /tmp/disks
+        echo "part /boot --fstype="xfs" --ondisk=$d1 --size=1024" >> /tmp/disks
+    %end
+
+
+Leverage ``%include /tmp/disks`` in the kickstart file to utilize.


### PR DESCRIPTION
Clarify that /dev/disk/by-path are not 100% reliable.  Add section
on selecting disks by size for installations which have consistent
disk configuration.

Signed-off-by: Tony Asleson <tasleson@redhat.com>