### PR TITLE
Add RHEL 9 handler

### DIFF
--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -649,3 +649,8 @@ class RHEL8_AutoPart(F29_AutoPart):
 
                     Partitioning scheme 'btrfs' was removed.""" % versionToLongString(RHEL8)
         return op
+
+
+class RHEL9_AutoPart(RHEL8_AutoPart):
+    pass
+

--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -513,3 +513,6 @@ class F34_Bootloader(F29_Bootloader):
         op = F29_Bootloader._getParser(self)
         op.remove_argument("--upgrade", version=F34)
         return op
+
+class RHEL9_Bootloader(F34_Bootloader):
+    pass

--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -276,3 +276,6 @@ class RHEL8_BTRFS(DeprecatedCommand, F23_BTRFS):
         op = F23_BTRFS._getParser(self)
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(RHEL8)
         return op
+
+class RHEL9_BTRFS(RHEL8_BTRFS):
+    pass

--- a/pykickstart/commands/fcoe.py
+++ b/pykickstart/commands/fcoe.py
@@ -106,6 +106,9 @@ class F28_FcoeData(F13_FcoeData):
 class RHEL8_FcoeData(F28_FcoeData):
     pass
 
+class RHEL9_FcoeData(F28_FcoeData):
+    pass
+
 class F12_Fcoe(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
@@ -191,4 +194,7 @@ class F28_Fcoe(F13_Fcoe):
         return op
 
 class RHEL8_Fcoe(F28_Fcoe):
+    pass
+
+class RHEL9_Fcoe(F28_Fcoe):
     pass

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -942,3 +942,6 @@ class RHEL8_LogVol(F29_LogVol):
 
                     Btrfs support was removed.""" % versionToLongString(RHEL8)
         return op
+
+class RHEL9_LogVol(RHEL8_LogVol):
+    pass

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -90,3 +90,6 @@ class RHEL7_OSTreeSetup(F21_OSTreeSetup):
 
 class RHEL8_OSTreeSetup(F21_OSTreeSetup):
     pass
+
+class RHEL9_OSTreeSetup(F21_OSTreeSetup):
+    pass

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -769,3 +769,26 @@ class F34_Partition(F29_Partition):
         op = F29_Partition._getParser(self)
         op.remove_argument("--active", version=F34)
         return op
+
+
+class RHEL9_Partition(F34_Partition):
+    removedKeywords = F34_Partition.removedKeywords
+    removedAttrs = F34_Partition.removedAttrs
+
+    def parse(self, args):
+        retval = F34_Partition.parse(self, args)
+        if retval.mountpoint.startswith("btrfs.") or retval.fstype == "btrfs":
+            raise KickstartParseError(_("Btrfs file system is not supported"), lineno=self.lineno)
+        return retval
+
+    def _getParser(self):
+        "Only necessary for the type change documentation"
+        op = F34_Partition._getParser(self)
+        for action in op._actions:
+            if "--fstype" in action.option_strings:
+                action.help += """
+
+                    .. versionchanged:: %s
+
+                    Btrfs support was removed.""" % versionToLongString(RHEL8)
+        return op

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -810,3 +810,6 @@ class RHEL8_Raid(F29_Raid):
 
                     Btrfs support was removed.""" % versionToLongString(RHEL8)
         return op
+
+class RHEL9_Raid(RHEL8_Raid):
+    pass

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -95,6 +95,9 @@ class RHEL7_VolGroupData(F21_VolGroupData):
 class RHEL8_VolGroupData(F21_VolGroupData):
     pass
 
+class RHEL9_VolGroupData(F21_VolGroupData):
+    pass
+
 class FC3_VolGroup(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
@@ -235,4 +238,7 @@ class RHEL7_VolGroup(F21_VolGroup):
     pass
 
 class RHEL8_VolGroup(F21_VolGroup):
+    pass
+
+class RHEL9_VolGroup(F21_VolGroup):
     pass

--- a/pykickstart/handlers/rhel9.py
+++ b/pykickstart/handlers/rhel9.py
@@ -1,0 +1,128 @@
+#
+# Martin Kolman <mkolman@redhat.com>
+#
+# Copyright 2021 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+__all__ = ["RHEL9Handler"]
+
+from pykickstart import commands
+from pykickstart.base import BaseHandler
+from pykickstart.version import RHEL9
+
+class RHEL9Handler(BaseHandler):
+    version = RHEL9
+
+    commandMap = {
+        "auth": commands.authconfig.F28_Authconfig,
+        "authconfig": commands.authconfig.F28_Authconfig,
+        "authselect": commands.authselect.F28_Authselect,
+        "autopart": commands.autopart.RHEL9_AutoPart,
+        "autostep": commands.autostep.F34_AutoStep,
+        "bootloader": commands.bootloader.RHEL9_Bootloader,
+        "btrfs": commands.btrfs.RHEL9_BTRFS,
+        "cdrom": commands.cdrom.FC3_Cdrom,
+        "clearpart": commands.clearpart.F28_ClearPart,
+        "cmdline": commands.displaymode.F26_DisplayMode,
+        "device": commands.device.F34_Device,
+        "deviceprobe": commands.deviceprobe.F34_DeviceProbe,
+        "dmraid": commands.dmraid.F34_DmRaid,
+        "driverdisk": commands.driverdisk.F14_DriverDisk,
+        "module": commands.module.F31_Module,
+        "eula": commands.eula.F20_Eula,
+        "fcoe": commands.fcoe.RHEL9_Fcoe,
+        "firewall": commands.firewall.F28_Firewall,
+        "firstboot": commands.firstboot.FC3_Firstboot,
+        "graphical": commands.displaymode.F26_DisplayMode,
+        "group": commands.group.F12_Group,
+        "halt": commands.reboot.F23_Reboot,
+        "harddrive": commands.harddrive.F33_HardDrive,
+        "hmc": commands.hmc.F28_Hmc,
+        "ignoredisk": commands.ignoredisk.F34_IgnoreDisk,
+        "install": commands.install.F34_Install,
+        "iscsi": commands.iscsi.F17_Iscsi,
+        "iscsiname": commands.iscsiname.FC6_IscsiName,
+        "keyboard": commands.keyboard.F18_Keyboard,
+        "lang": commands.lang.F19_Lang,
+        "liveimg": commands.liveimg.F19_Liveimg,
+        "logging": commands.logging.F34_Logging,
+        "logvol": commands.logvol.RHEL9_LogVol,
+        "mediacheck": commands.mediacheck.FC4_MediaCheck,
+        "method": commands.method.F34_Method,
+        "mount": commands.mount.F27_Mount,
+        "multipath": commands.multipath.F34_MultiPath,
+        "network": commands.network.F27_Network,
+        "nfs": commands.nfs.FC6_NFS,
+        "nvdimm": commands.nvdimm.F28_Nvdimm,
+        "timesource": commands.timesource.F33_Timesource,
+        "ostreesetup": commands.ostreesetup.RHEL9_OSTreeSetup,
+        "part": commands.partition.RHEL9_Partition,
+        "partition": commands.partition.RHEL9_Partition,
+        "poweroff": commands.reboot.F23_Reboot,
+        "raid": commands.raid.RHEL9_Raid,
+        "realm": commands.realm.F19_Realm,
+        "reboot": commands.reboot.F23_Reboot,
+        "repo": commands.repo.F33_Repo,
+        "reqpart": commands.reqpart.F23_ReqPart,
+        "rescue": commands.rescue.F10_Rescue,
+        "rhsm": commands.rhsm.RHEL8_RHSM,
+        "rootpw": commands.rootpw.F18_RootPw,
+        "selinux": commands.selinux.FC3_SELinux,
+        "services": commands.services.FC6_Services,
+        "shutdown": commands.reboot.F23_Reboot,
+        "skipx": commands.skipx.FC3_SkipX,
+        "snapshot": commands.snapshot.F26_Snapshot,
+        "sshpw": commands.sshpw.F24_SshPw,
+        "sshkey": commands.sshkey.F22_SshKey,
+        "syspurpose" : commands.syspurpose.RHEL8_Syspurpose,
+        "text": commands.displaymode.F26_DisplayMode,
+        "timezone": commands.timezone.F33_Timezone,
+        "updates": commands.updates.F34_Updates,
+        "url": commands.url.F30_Url,
+        "user": commands.user.F24_User,
+        "vnc": commands.vnc.F9_Vnc,
+        "volgroup": commands.volgroup.RHEL9_VolGroup,
+        "xconfig": commands.xconfig.F14_XConfig,
+        "zerombr": commands.zerombr.F9_ZeroMbr,
+        "zfcp": commands.zfcp.F14_ZFCP,
+        "zipl": commands.zipl.F32_Zipl,
+    }
+
+    dataMap = {
+        "BTRFSData": commands.btrfs.F23_BTRFSData,
+        "DriverDiskData": commands.driverdisk.F14_DriverDiskData,
+        "DeviceData": commands.device.F8_DeviceData,
+        "DmRaidData": commands.dmraid.FC6_DmRaidData,
+        "ModuleData": commands.module.F31_ModuleData,
+        "TimesourceData": commands.timesource.F33_TimesourceData,
+        "FcoeData": commands.fcoe.RHEL9_FcoeData,
+        "GroupData": commands.group.F12_GroupData,
+        "IscsiData": commands.iscsi.F17_IscsiData,
+        "LogVolData": commands.logvol.F29_LogVolData,
+        "MountData": commands.mount.F27_MountData,
+        "MultiPathData": commands.multipath.FC6_MultiPathData,
+        "NetworkData": commands.network.F27_NetworkData,
+        "NvdimmData": commands.nvdimm.F28_NvdimmData,
+        "PartData": commands.partition.F29_PartData,
+        "RaidData": commands.raid.F29_RaidData,
+        "RepoData": commands.repo.F30_RepoData,
+        "SnapshotData": commands.snapshot.F26_SnapshotData,
+        "SshPwData": commands.sshpw.F24_SshPwData,
+        "SshKeyData": commands.sshkey.F22_SshKeyData,
+        "UserData": commands.user.F19_UserData,
+        "VolGroupData": commands.volgroup.RHEL9_VolGroupData,
+        "ZFCPData": commands.zfcp.F14_ZFCPData,
+    }

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -93,6 +93,7 @@ F31 = 31000
 F32 = 32000
 F33 = 33000
 F34 = 34000
+RHEL9 = 34100
 F35 = 35000
 
 # This always points at the latest version and is the default.
@@ -109,7 +110,7 @@ versionMap = {
     "F29": F29, "F30": F30, "F31": F31, "F32": F32, "F33": F33,
     "F34": F34, "F35": F35,
     "RHEL3": RHEL3, "RHEL4": RHEL4, "RHEL5": RHEL5, "RHEL6": RHEL6,
-    "RHEL7": RHEL7, "RHEL8": RHEL8
+    "RHEL7": RHEL7, "RHEL8": RHEL8, "RHEL9": RHEL9
 }
 
 def stringToVersion(s):

--- a/tests/commands/partition.py
+++ b/tests/commands/partition.py
@@ -343,5 +343,10 @@ class F34_TestCase(F29_TestCase):
         self.assert_removed("part", "--active")
         self.assert_removed("partition", "--active")
 
+class RHEL9_TestCase(F29_TestCase):
+    def  runTest(self):
+        F29_TestCase.runTest(self)
+        self.assert_parse_error("part / --fstype=btrfs")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/version.py
+++ b/tests/version.py
@@ -193,6 +193,13 @@ class StringToVersion_TestCase(CommandTest):
             self.assertEqual(stringToVersion("Red Hat Enterprise Linux 8.%s" % MINOR), RHEL8)
         self.assertEqual(stringToVersion("RHEL8"), RHEL8)
 
+        # pass - RHEL9
+        self.assertEqual(stringToVersion("Red Hat Enterprise Linux 9"), RHEL9)
+        for MINOR in range(1,10):
+            self.assertEqual(stringToVersion("Red Hat Enterprise Linux 9.%s" % MINOR), RHEL9)
+        self.assertEqual(stringToVersion("RHEL9"), RHEL9)
+
+
 class VersionToString_TestCase(CommandTest):
     def runTest(self):
 
@@ -252,6 +259,7 @@ class VersionToString_TestCase(CommandTest):
         self.assertEqual(versionToString(RHEL6), "RHEL6")
         self.assertEqual(versionToString(RHEL7), "RHEL7")
         self.assertEqual(versionToString(RHEL8), "RHEL8")
+        self.assertEqual(versionToString(RHEL9), "RHEL9")
 
         # fail
         self.assertRaises(KickstartVersionError, versionToString, 47)


### PR DESCRIPTION
Add handler for RHEL 9, so that RHEL only commands and RHEL command
variations can be used in Anaconda on RHEL 9.

The RHEL 8 version of the handler was created by commits:
16ff122476ba01874a154b7e45204b8a71e6cdf5
b13b5a1e512c0705aa295c29526e8615da6e6296

Resolves: rhbz#1966730