### PR TITLE
tests: Use pykickstart/commands relative to the import

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,7 @@ import unittest.mock as mock
 from argparse import Namespace
 
 from tests.baseclass import ParserTest
+import pykickstart
 from pykickstart.parser import Script, KickstartParser
 from pykickstart.version import F25
 from pykickstart.handlers.f25 import F25Handler
@@ -61,7 +62,7 @@ class DeleteRemovedAttrs_TestCase(unittest.TestCase):
     """
     def runTest(self):
         errors = []
-        commands_dir = os.path.join(os.path.dirname(__file__), "..", "pykickstart", "commands")
+        commands_dir = os.path.join(os.path.dirname(pykickstart.__file__), "commands")
         commands_dir = os.path.abspath(commands_dir)
 
         self.assertTrue(os.path.exists(commands_dir))

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 import importlib
 from unittest import mock
+import pykickstart
 from pykickstart.options import KSOptionParser
 from pykickstart.base import KickstartCommand, BaseData
 
@@ -22,7 +23,7 @@ class ClassDefinitionTestCase(unittest.TestCase):
     """
     def runTest(self):
         errors = 0
-        commands_dir = os.path.join(os.path.dirname(__file__), "..", "..", "pykickstart", "commands")
+        commands_dir = os.path.join(os.path.dirname(pykickstart.__file__), "commands")
         commands_dir = os.path.abspath(commands_dir)
 
         self.assertTrue(os.path.exists(commands_dir))
@@ -90,7 +91,7 @@ class HelpAndDescription_TestCase(unittest.TestCase):
 
     def runTest(self):
         errors = 0
-        commands_dir = os.path.join(os.path.dirname(__file__), "..", "..", "pykickstart", "commands")
+        commands_dir = os.path.join(os.path.dirname(pykickstart.__file__), "commands")
         commands_dir = os.path.abspath(commands_dir)
 
         self.assertTrue(os.path.exists(commands_dir))


### PR DESCRIPTION
When testing an installed package instead of the source tree the test
needs to examine the installed source path, not the path relative to the
test.

Related: rhbz#1968762