### PR TITLE
remove authconfig support

### DIFF
--- a/pykickstart/commands/authconfig.py
+++ b/pykickstart/commands/authconfig.py
@@ -15,14 +15,14 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
 # trademarks that are incorporated in the source code or documentation are not
 # subject to the GNU General Public License and may only be used or replicated
-# with the express permission of Red Hat, Inc. 
+# with the express permission of Red Hat, Inc.
 #
 import warnings
 from textwrap import dedent
 
 from pykickstart.errors import KickstartDeprecationWarning
-from pykickstart.version import FC3, versionToLongString, F28
-from pykickstart.base import KickstartCommand
+from pykickstart.version import FC3, versionToLongString, F28, F35
+from pykickstart.base import KickstartCommand, RemovedCommand
 from pykickstart.options import KSOptionParser
 
 
@@ -83,4 +83,10 @@ class F28_Authconfig(FC3_Authconfig):
             command instead.
 
         """ % versionToLongString(F28))
+        return op
+
+class F35_Authconfig(RemovedCommand, F28_Authconfig):
+    def _getParser(self):
+        op = F28_Authconfig._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F35)
         return op

--- a/pykickstart/handlers/f35.py
+++ b/pykickstart/handlers/f35.py
@@ -25,8 +25,8 @@ class F35Handler(BaseHandler):
     version = F35
 
     commandMap = {
-        "auth": commands.authconfig.F28_Authconfig,
-        "authconfig": commands.authconfig.F28_Authconfig,
+        "auth": commands.authconfig.F35_Authconfig, # RemovedCommand
+        "authconfig": commands.authconfig.F35_Authconfig, # RemovedCommand
         "authselect": commands.authselect.F28_Authselect,
         "autopart": commands.autopart.F29_AutoPart,
         "autostep": commands.autostep.F34_AutoStep,

--- a/tests/commands/authconfig.py
+++ b/tests/commands/authconfig.py
@@ -1,5 +1,6 @@
 import unittest
 
+from pykickstart.base import RemovedCommand
 from pykickstart.errors import KickstartDeprecationWarning
 from tests.baseclass import CommandTest
 
@@ -27,6 +28,18 @@ class F28_TestCase(FC3_TestCase):
 
         with self.assertWarns(KickstartDeprecationWarning):
             self.assert_parse("auth")
+
+
+class F35_TestCase(F28_TestCase):
+
+    def runTest(self):
+        # make sure that auth is removed
+        cmd = self.handler().commands["auth"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
+
+        # make sure that authconfig is removed
+        cmd = self.handler().commands["authconfig"]
+        self.assertTrue(issubclass(cmd.__class__, RemovedCommand))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Authconfig compatibility tool (from authselect-compat) will be removed from Fedora 35:
https://fedoraproject.org/wiki/Changes/RemoveAuthselectCompatPackage