### PR TITLE
Be more consistent when referring to `%pre`

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -387,7 +387,7 @@ class OnErrorScriptSection(ScriptSection):
     a bug in the installer.  Some examples of these situations include errors in
     packages that have been requested to be installed, failures when starting VNC
     when requested, and error when scanning storage.  When these situations happen,
-    installaton cannot continue.  The installer will run all %onerror scripts in
+    installation cannot continue.  The installer will run all %onerror scripts in
     the order they are provided in the kickstart file.
 
     In addition, %onerror scripts will be run on a traceback as well.  To be exact,

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -239,7 +239,7 @@ class PreScriptSection(ScriptSection):
 
         .. note::
 
-            The pre-install script is not run in the chroot environment.
+            The pre-installation script is not run in the chroot environment.
     """
     _epilog = """
     Example


### PR DESCRIPTION
The next section describes `%pre-install` and refers to it as "pre-install" script, so this is confusing, possibly even misleading.

**warning** I'm sneaking in also a typo fix in a separate commit :)