### PR TITLE
ksvalidator: Handle empty files

### DIFF
--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -124,7 +124,7 @@ def preprocessFromString(s):
        run.  Returns the location of the complete kickstart file.
     """
     s = preprocessFromStringToString(s)
-    if s:
+    if s.strip():
         import tempfile
         (outF, outName) = tempfile.mkstemp(suffix="-ks.cfg")
 
@@ -141,7 +141,7 @@ def preprocessKickstart(f):
        run.  Returns the location of the complete kickstart file.
     """
     s = preprocessKickstartToString(f)
-    if s:
+    if s.strip():
         import tempfile
         (outF, outName) = tempfile.mkstemp(suffix="-ks.cfg")
 

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -181,6 +181,15 @@ timezone America/New_York
         with open(self._path) as f:
             self.assertEqual(f.read(), self.ks + self.ksappend)
 
+class PFS_Ksappend_Empty(PFS_No_Ksappend):
+    def __init__(self, *args, **kwargs):
+        PFS_No_Ksappend.__init__(self, *args, **kwargs)
+
+    def runTest(self):
+        self.assertEqual(preprocessFromString(""), None)
+        self.assertEqual(preprocessFromString(" "), None)
+        self.assertEqual(preprocessFromString("  \n  \n       \n\n  "), None)
+
 ###
 ### TESTING preprocessKickstartToString
 ###

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -103,6 +103,8 @@ def main(argv):
 
     try:
         processedFile = preprocessKickstart(f)
+        if processedFile is None:
+            raise RuntimeError("Empty file")
         ksparser.readKickstart(processedFile)
         return (cleanup(destdir, processedFile, exitval=ksparser.errorsCount), [])
     except KickstartDeprecationWarning as err:


### PR DESCRIPTION
Previously an empty file would return a confusing error. This fixes it
by checking the preprocess call for None, and by running strip on the
file before checking if it is empty. Also includes tests.

Fixes #388