### PR TITLE
Fix validation of packages arguments

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -627,7 +627,7 @@ class PackageSection(Section):
 
         op.remove_argument("--ignoredeps", version=F9)
         op.remove_argument("--resolvedeps", version=F9)
-        op.add_argument("--instLangs", "--inst-langs", default=None, version=F9, help="""
+        op.add_argument("--instLangs", default=None, version=F9, help="""
                         Specify the list of languages that should be installed.
                         This is different from the package group level
                         selections, though. This option does not specify what
@@ -686,7 +686,7 @@ class PackageSection(Section):
         if self.version < F24:
             return op
 
-        op.add_argument("--excludeWeakdeps", "--exclude-weakdeps", dest="excludeWeakdeps",
+        op.add_argument("--excludeWeakdeps", dest="excludeWeakdeps",
                         action="store_true", default=False, version=F24,
                         help="""
                         Do not install packages from weak dependencies. These
@@ -696,6 +696,13 @@ class PackageSection(Section):
 
         if self.version < F32:
             return op
+
+        op.add_argument("--instLangs", "--inst-langs", dest="instLangs", default=None,
+                        version=F32, help="Added ``--inst-langs`` alias")
+
+        op.add_argument("--excludeWeakdeps", "--exclude-weakdeps", dest="excludeWeakdeps",
+                        action="store_true", default=False, version=F32,
+                        help="Added ``--exclude-weakdeps`` alias")
 
         op.add_argument("--ignorebroken", action="store_true", default=False, version=F32,
                         help="""
@@ -779,11 +786,12 @@ class PackageSection(Section):
         else:
             self.handler.packages.handleBroken = KS_BROKEN_REPORT
 
-        for option, new_option in \
+        for arg in args:
+            for option, new_option in \
                 {"--instLangs": "--inst-langs", "--excludeWeakdeps": "--exclude-weakdeps"}.items():
-            if option in args:
-                warnings.warn(_("The %(option)s option on line %(lineno)s will be deprecated in "
-                                "future releases. Please modify your kickstart file to replace "
-                                "this option with its preferred alias %(new_option)s.")
-                              % {"option": option, "lineno": lineno, "new_option": new_option},
-                              KickstartDeprecationWarning)
+                if option in arg:
+                    warnings.warn(_("The %(option)s option on line %(lineno)s will be deprecated in "
+                                    "future releases. Please modify your kickstart file to replace "
+                                    "this option with its preferred alias %(new_option)s.")
+                                  % {"option": option, "lineno": lineno, "new_option": new_option},
+                                  KickstartDeprecationWarning)

--- a/tests/tools/ksvalidator.py
+++ b/tests/tools/ksvalidator.py
@@ -156,7 +156,7 @@ class URL_KS_File_TestCase(TestCase):
     @mock.patch("tools.ksvalidator.load_to_file")
     def runTest(self, load_mock):
         load_mock.return_value = self._ks_path
-        retval, out = ksvalidator.main(["http://example.com/some.kickstart/is/online"])
+        retval, _ = ksvalidator.main(["http://example.com/some.kickstart/is/online"])
         print(locals())
         self.assertEqual(retval, 0)
 
@@ -256,4 +256,38 @@ class Raise_DeprecationWarning_TestCase(TestCase):
 
     def tearDown(self):
         super(Raise_DeprecationWarning_TestCase, self).tearDown()
+        os.unlink(self._ks_path)
+
+class PackagesSectionCamelCase_TestCase(TestCase):
+    def setUp(self):
+        super(PackagesSectionCamelCase_TestCase, self).setUp()
+        ks_content = "%packages --instLangs=en\n%end\n"
+        self._ks_path = mktempfile(ks_content)
+
+    def runTest(self):
+        retval, out = ksvalidator.main([self._ks_path, "-v", "F9"])
+        self.assertEqual(retval, 0)
+
+        retval, out = ksvalidator.main([self._ks_path, "-v", "F32"])
+        self.assertNotEqual(retval, 0)
+
+    def tearDown(self):
+        super(PackagesSectionCamelCase_TestCase, self).tearDown()
+        os.unlink(self._ks_path)
+
+class PackagesSectionLowerCase_TestCase(TestCase):
+    def setUp(self):
+        super(PackagesSectionLowerCase_TestCase, self).setUp()
+        ks_content = "%packages --inst-langs=en\n%end\n"
+        self._ks_path = mktempfile(ks_content)
+
+    def runTest(self):
+        retval, out = ksvalidator.main([self._ks_path, "-v", "F9"])
+        self.assertNotEqual(retval, 0)
+
+        retval, out = ksvalidator.main([self._ks_path, "-v", "F32"])
+        self.assertEqual(retval, 0)
+
+    def tearDown(self):
+        super(PackagesSectionLowerCase_TestCase, self).tearDown()
         os.unlink(self._ks_path)

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -99,7 +99,7 @@ def main(argv):
     # iterate over files to check them
     with tempfile.TemporaryDirectory(prefix="ksvalidator-tmp-") as destdir:
         for ksfile in ksfiles:
-            print(_("\nChecking kickstart file %(filename)s\n" % {"filename": ksfile}))
+            print(_("\nChecking kickstart file %(filename)s\n") % {"filename": ksfile})
 
             try:
                 f = load_to_file(ksfile, os.path.join(destdir, "ks.cfg"))


### PR DESCRIPTION
In Fedora 32 we added the lower-case versions of --instLangs and
--excludeWeakdeps by extending the current entries. This causes problems
when trying to use ksvalidate. It would not fail if --inst-langs was
passed to RHEL8 for example.

Fixes #395