### PR TITLE
Remove the --ignorebroken option from RHEL handlers

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -36,7 +36,8 @@ from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACE
                                   KS_BROKEN_IGNORE, KS_BROKEN_REPORT
 from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.options import KSOptionParser
-from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, F34, RHEL6, RHEL7
+from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, F34, RHEL6, RHEL7, RHEL9, \
+    isRHEL
 from pykickstart.i18n import _
 
 class Section(object):
@@ -716,6 +717,10 @@ class PackageSection(Section):
                         were skipped. Using this option may result in an unusable system.**
                         """)
 
+        if isRHEL(self.version):
+            # The --ignorebroken feature is not supported on RHEL.
+            op.remove_argument("--ignorebroken", version=RHEL9)
+
         return op
 
     def handleHeader(self, lineno, args):
@@ -781,7 +786,7 @@ class PackageSection(Section):
         if self.version < F32:
             return
 
-        if ns.ignorebroken:
+        if getattr(ns, "ignorebroken", False):
             self.handler.packages.handleBroken = KS_BROKEN_IGNORE
         else:
             self.handler.packages.handleBroken = KS_BROKEN_REPORT

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -228,3 +228,6 @@ def makeVersion(version=DEVEL):
 
 def getVersionFromCommandClass(cls):
     return versionMap[cls.__name__.split('_')[0]]
+
+def isRHEL(version):
+    return "RHEL" in versionToString(version, skipDevel=True)

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -7,7 +7,7 @@ from pykickstart.constants import KS_MISSING_IGNORE, KS_MISSING_PROMPT, \
     KS_BROKEN_IGNORE, KS_BROKEN_REPORT
 from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.parser import Group, Packages
-from pykickstart.version import DEVEL, F7, F21, RHEL6, returnClassForVersion, RHEL7, F32
+from pykickstart.version import DEVEL, F7, F21, RHEL6, returnClassForVersion, RHEL7, F32, RHEL9
 
 
 class DevelPackagesBase(ParserTest):
@@ -590,6 +590,19 @@ class Packages_Warn_CamelCase_TestCase(ParserTest):
             self.assertEqual(len(w), 2)
             self.assertEqual(str(self.handler.packages),
                 "\n%packages --inst-langs=cs_CZ --exclude-weakdeps\nsomething\n\n%end\n")
+
+class Packages_IgnoreBroken_RHEL_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.version = RHEL9
+        self.ks = "%packages --ignorebroken\n%end\n"
+
+    def runTest(self):
+        with self.assertRaises(KickstartParseError) as cm:
+            self.parser.readKickstartFromString(self.ks)
+
+        expected = "unrecognized arguments: --ignorebroken"
+        self.assertIn(expected, str(cm.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/version.py
+++ b/tests/version.py
@@ -272,6 +272,20 @@ class VersionToString_TestCase(CommandTest):
         # fail
         self.assertRaises(KickstartVersionError, versionToString, 47)
 
+class IsRHEL_TestCase(CommandTest):
+    def runTest(self):
+        self.assertFalse(isRHEL(DEVEL))
+
+        self.assertFalse(isRHEL(F32))
+        self.assertFalse(isRHEL(F33))
+        self.assertFalse(isRHEL(F34))
+        self.assertFalse(isRHEL(F35))
+
+        self.assertTrue(isRHEL(RHEL6))
+        self.assertTrue(isRHEL(RHEL7))
+        self.assertTrue(isRHEL(RHEL8))
+        self.assertTrue(isRHEL(RHEL9))
+
 class returnClassForVersion_TestCase(CommandTest):
     def runTest(self):
 


### PR DESCRIPTION
The `%packages --ignorebroken` feature is not supported on RHEL. Handle
this use case in pykickstart, so we don't have to deal with it in anaconda.

Tested on F37 and RHEL9.