### PR TITLE
Backport dropping --ignorebroken

### DIFF
--- a/docs/gen_sections_docs
+++ b/docs/gen_sections_docs
@@ -2,7 +2,7 @@
 import sys
 sys.path.insert(0, "../")
 from pykickstart import sections
-from pykickstart.version import returnClassForVersion, DEVEL
+from pykickstart.version import returnClassForVersion
 
 def _format_title(title, underline = '-'):
     t = title.replace('|', ' or ')
@@ -10,7 +10,7 @@ def _format_title(title, underline = '-'):
 
 if __name__ == "__main__":
     chapter = 4
-    handler = returnClassForVersion(DEVEL)
+    handler = returnClassForVersion()
     for _, section_class in sections.__dict__.items():
         # skip everything which isn't a class
         if type(section_class) is not type:

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -36,7 +36,8 @@ from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACE
                                   KS_BROKEN_IGNORE, KS_BROKEN_REPORT
 from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.options import KSOptionParser
-from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, F34, RHEL6, RHEL7
+from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, F32, F34, RHEL6, RHEL7, RHEL9, \
+    isRHEL
 from pykickstart.i18n import _
 
 class Section(object):
@@ -716,6 +717,10 @@ class PackageSection(Section):
                         were skipped. Using this option may result in an unusable system.**
                         """)
 
+        if isRHEL(self.version):
+            # The --ignorebroken feature is not supported on RHEL.
+            op.remove_argument("--ignorebroken", version=RHEL9)
+
         return op
 
     def handleHeader(self, lineno, args):
@@ -781,7 +786,7 @@ class PackageSection(Section):
         if self.version < F32:
             return
 
-        if ns.ignorebroken:
+        if getattr(ns, "ignorebroken", False):
             self.handler.packages.handleBroken = KS_BROKEN_IGNORE
         else:
             self.handler.packages.handleBroken = KS_BROKEN_REPORT

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -225,3 +225,6 @@ def makeVersion(version=DEVEL):
 
 def getVersionFromCommandClass(cls):
     return versionMap[cls.__name__.split('_')[0]]
+
+def isRHEL(version):
+    return "RHEL" in versionToString(version, skipDevel=True)

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -174,7 +174,7 @@ def versionFromFile(f):
     """Given a file or URL, look for a line starting with #version= and
        return the version number.  If no version is found, return DEVEL.
     """
-    v = DEVEL
+    v = RHEL9
 
     contents = load_to_str(f)
 
@@ -188,7 +188,7 @@ def versionFromFile(f):
 
     return v
 
-def returnClassForVersion(version=DEVEL):
+def returnClassForVersion(version=RHEL9):
     """Return the class of the syntax handler for version.  version can be
        either a string or the matching constant.  Raises KickstartVersionError
        if version does not match anything.
@@ -213,7 +213,7 @@ def returnClassForVersion(version=DEVEL):
     except:
         raise KickstartVersionError(_("Unsupported version specified: %s") % version)
 
-def makeVersion(version=DEVEL):
+def makeVersion(version=RHEL9):
     """Return a new instance of the syntax handler for version.  version can be
        either a string or the matching constant.  This function is useful for
        standalone programs which just need to handle a specific version of

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -7,7 +7,7 @@ from pykickstart.constants import KS_MISSING_IGNORE, KS_MISSING_PROMPT, \
     KS_BROKEN_IGNORE, KS_BROKEN_REPORT
 from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.parser import Group, Packages
-from pykickstart.version import DEVEL, F7, F21, RHEL6, returnClassForVersion, RHEL7, F32
+from pykickstart.version import DEVEL, F7, F21, RHEL6, returnClassForVersion, RHEL7, F32, RHEL9
 
 
 class DevelPackagesBase(ParserTest):
@@ -590,6 +590,19 @@ class Packages_Warn_CamelCase_TestCase(ParserTest):
             self.assertEqual(len(w), 2)
             self.assertEqual(str(self.handler.packages),
                 "\n%packages --inst-langs=cs_CZ --exclude-weakdeps\nsomething\n\n%end\n")
+
+class Packages_IgnoreBroken_RHEL_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.version = RHEL9
+        self.ks = "%packages --ignorebroken\n%end\n"
+
+    def runTest(self):
+        with self.assertRaises(KickstartParseError) as cm:
+            self.parser.readKickstartFromString(self.ks)
+
+        expected = "unrecognized arguments: --ignorebroken"
+        self.assertIn(expected, str(cm.exception))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/ksshell.py
+++ b/tests/tools/ksshell.py
@@ -2,7 +2,7 @@ from tools import ksshell
 import unittest.mock as mock
 from unittest import TestCase
 
-from pykickstart.version import DEVEL, makeVersion
+from pykickstart.version import makeVersion
 
 
 class InvalidKSVersion_Test(TestCase):
@@ -14,7 +14,7 @@ class InvalidKSVersion_Test(TestCase):
 
 class KickstartCompleter_Test(TestCase):
     def runTest(self):
-        kshandler = makeVersion(DEVEL)
+        kshandler = makeVersion()
         self.assertIsNotNone(kshandler)
 
         # Did it add the commands, and is there at least one (part) that should be present?

--- a/tests/version.py
+++ b/tests/version.py
@@ -318,14 +318,14 @@ class versionFromFile_TestCase(CommandTest):
             os.close(fd)
             return name
 
-        # no version specified
+        # no version specified (on RHEL9 this defaults to RHEL9)
         ks_cfg = '''
 # This is a sample kickstart file
 rootpw testing123
 cdrom
 '''
         ks_cfg = write_ks_cfg(ks_cfg)
-        self.assertEqual(versionFromFile(ks_cfg), DEVEL)
+        self.assertEqual(versionFromFile(ks_cfg), RHEL9)
         os.unlink(ks_cfg)
 
         # proper format ... DEVEL
@@ -350,7 +350,7 @@ cdrom
         self.assertEqual(versionFromFile(ks_cfg), RHEL3)
         os.unlink(ks_cfg)
 
-        # improper format ... fallback to DEVEL
+        # improper format ... fallback to DEVEL (on RHEL9 falls back to RHEL9)
         ks_cfg = '''
 # This is a sample kickstart file
 # version: FC3
@@ -358,7 +358,7 @@ rootpw testing123
 cdrom
 '''
         ks_cfg = write_ks_cfg(ks_cfg)
-        self.assertEqual(versionFromFile(ks_cfg), DEVEL)
+        self.assertEqual(versionFromFile(ks_cfg), RHEL9)
         os.unlink(ks_cfg)
 
         # unknown version specified ... raise exception

--- a/tests/version.py
+++ b/tests/version.py
@@ -261,6 +261,19 @@ class VersionToString_TestCase(CommandTest):
         # fail
         self.assertRaises(KickstartVersionError, versionToString, 47)
 
+class IsRHEL_TestCase(CommandTest):
+    def runTest(self):
+        self.assertFalse(isRHEL(DEVEL))
+
+        self.assertFalse(isRHEL(F32))
+        self.assertFalse(isRHEL(F33))
+        self.assertFalse(isRHEL(F34))
+
+        self.assertTrue(isRHEL(RHEL6))
+        self.assertTrue(isRHEL(RHEL7))
+        self.assertTrue(isRHEL(RHEL8))
+        self.assertTrue(isRHEL(RHEL9))
+
 class returnClassForVersion_TestCase(CommandTest):
     def runTest(self):
 

--- a/tools/ksflatten.py
+++ b/tools/ksflatten.py
@@ -27,14 +27,14 @@ import argparse
 import pykickstart
 import pykickstart.parser
 from pykickstart.i18n import _
-from pykickstart.version import DEVEL, makeVersion
+from pykickstart.version import RHEL9, makeVersion
 from pykickstart.errors import KickstartVersionError
 
 def parse_args(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", dest="kscfg", required=True,
                         help=_("Path to kickstart config file"))
-    parser.add_argument("-v", "--version", dest="version", default=DEVEL,
+    parser.add_argument("-v", "--version", dest="version", default=RHEL9,
                         help=_("Kickstart version to use for interpreting config"))
     parser.add_argument("-o", "--output", dest="output",
                         help=_("Write flattened config to OUTPUT"))

--- a/tools/ksshell.py
+++ b/tools/ksshell.py
@@ -42,7 +42,7 @@ import os, six, sys
 from pykickstart.i18n import _
 from pykickstart.errors import KickstartError, KickstartVersionError
 from pykickstart.parser import KickstartParser, preprocessKickstart
-from pykickstart.version import DEVEL, makeVersion
+from pykickstart.version import RHEL9, makeVersion
 
 ##
 ## INTERNAL COMMANDS
@@ -152,7 +152,7 @@ def main(argv=None):
                     help=_("a basis file to use for seeding the kickstart data (optional)"))
     op.add_argument("-o", "--output", dest="output",
                     help=_("the location to write the finished kickstart file, or stdout if not given"))
-    op.add_argument("-v", "--version", dest="version", default=DEVEL,
+    op.add_argument("-v", "--version", dest="version", default=RHEL9,
                     help=_("version of kickstart syntax to validate against"))
 
     opts = op.parse_args(argv)

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -33,7 +33,7 @@ from pykickstart.errors import KickstartError, KickstartParseError, KickstartVer
     KickstartParseWarning, KickstartDeprecationWarning
 from pykickstart.load import load_to_file
 from pykickstart.parser import KickstartParser, preprocessKickstart
-from pykickstart.version import DEVEL, makeVersion, versionMap
+from pykickstart.version import RHEL9, makeVersion, versionMap
 
 def cleanup(dest, fn=None, exitval=1):
     shutil.rmtree(dest)
@@ -59,7 +59,7 @@ def main(argv):
     op.add_argument("-l", "--listversions", dest="listversions", action="store_true",
                     default=False,
                     help=_("list the available versions of kickstart syntax"))
-    op.add_argument("-v", "--version", dest="version", default=DEVEL,
+    op.add_argument("-v", "--version", dest="version", default=RHEL9,
                     help=_("version of kickstart syntax to validate against"))
     op.add_argument("-h", "--help", dest="help", action="store_true", default=False,
                     help=_("show this help message and exit"))


### PR DESCRIPTION
This is the backport of pr #403 with additional changes fixing how RHEL9 selects the default pykickstart version to use.
