### PR TITLE
i18n: Pass gettext domain on every translation call

### DIFF
--- a/pykickstart/i18n.py
+++ b/pykickstart/i18n.py
@@ -25,7 +25,6 @@ def _find_locale_files():
     locale_path = os.path.join(os.path.dirname(module_path), 'locale')
 
     gettext.bindtextdomain("pykickstart", locale_path)
-    gettext.textdomain("pykickstart")
 _find_locale_files()
 
-_ = lambda x: gettext.gettext(x) if x else ''
+_ = lambda x: gettext.translation("pykickstart", fallback=True).gettext(x) if x != "" else ""


### PR DESCRIPTION
Previously it was changing the global gettext domain which could cause
problems for other applications. This updates it to pass the domain to
every call, and also switches to using the more robust .translation()
method as used by Anaconda.

Fixes #405