### PR TITLE
github: Fix workflow to only send coverage for python 3.9

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run check coverage and docs
         run: tox -e ${{ matrix.tox-env }}
       - name: Coveralls
-        if: ${{ matrix.python-version }} == 3.9
+        if: matrix.python-version == 3.9
         uses: AndreMiras/coveralls-python-action@develop
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ends up the if statement already evaluates it as an expression so you
don't use ${{ }} for the variables.