### PR TITLE
rootpw: Add an --allow-ssh argument

### DIFF
--- a/pykickstart/commands/rootpw.py
+++ b/pykickstart/commands/rootpw.py
@@ -17,7 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, F8
+from pykickstart.version import FC3, F8, F37
 from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
@@ -143,3 +143,27 @@ class F18_RootPw(F8_RootPw):
 
         self.set_to_self(ns)
         return self
+
+class F37_RootPw(F18_RootPw):
+    removedKeywords = F18_RootPw.removedKeywords
+    removedAttrs = F18_RootPw.removedAttrs
+
+    def __init__(self, writePriority=0, *args, **kwargs):
+        F18_RootPw.__init__(self, writePriority, *args, **kwargs)
+        self.allow_ssh = kwargs.get("allow_ssh", False)
+
+    def _getArgsAsStr(self):
+        retval = F18_RootPw._getArgsAsStr(self)
+
+        if self.allow_ssh:
+            retval += " --allow-ssh"
+
+        return retval
+
+    def _getParser(self):
+        op = F18_RootPw._getParser(self)
+        op.add_argument("--allow-ssh", action="store_true", default=False,
+                        version=F37, help="""
+                        This will allow remote root logins via ssh using only
+                        the password. Only use as a last resort.""")
+        return op

--- a/pykickstart/handlers/f37.py
+++ b/pykickstart/handlers/f37.py
@@ -76,7 +76,7 @@ class F37Handler(BaseHandler):
         "repo": commands.repo.F33_Repo,
         "reqpart": commands.reqpart.F23_ReqPart,
         "rescue": commands.rescue.F10_Rescue,
-        "rootpw": commands.rootpw.F18_RootPw,
+        "rootpw": commands.rootpw.F37_RootPw,
         "selinux": commands.selinux.FC3_SELinux,
         "services": commands.services.FC6_Services,
         "shutdown": commands.reboot.F23_Reboot,

--- a/pykickstart/handlers/rhel9.py
+++ b/pykickstart/handlers/rhel9.py
@@ -79,7 +79,7 @@ class RHEL9Handler(BaseHandler):
         "reqpart": commands.reqpart.F23_ReqPart,
         "rescue": commands.rescue.F10_Rescue,
         "rhsm": commands.rhsm.RHEL8_RHSM,
-        "rootpw": commands.rootpw.F18_RootPw,
+        "rootpw": commands.rootpw.F37_RootPw,
         "selinux": commands.selinux.FC3_SELinux,
         "services": commands.services.FC6_Services,
         "shutdown": commands.reboot.F23_Reboot,

--- a/tests/commands/rootpw.py
+++ b/tests/commands/rootpw.py
@@ -76,5 +76,16 @@ class F18_TestCase(F8_TestCase):
 
         self.assert_parse("rootpw --lock", "rootpw --lock\n")
 
+class F37_TestCase(F18_TestCase):
+    def runTest(self):
+        F18_TestCase.runTest(self)
+
+        obj = self.assert_parse("rootpw --plaintext --allow-ssh secrethandshake", "rootpw --plaintext --allow-ssh secrethandshake\n")
+        self.assertTrue(obj.allow_ssh)
+        obj = self.assert_parse("rootpw --iscrypted --lock --allow-ssh secrethandshake", "rootpw --iscrypted --lock --allow-ssh secrethandshake\n")
+        self.assertTrue(obj.allow_ssh)
+        obj = self.assert_parse("rootpw --iscrypted secrethandshake", "rootpw --iscrypted secrethandshake\n")
+        self.assertFalse(obj.allow_ssh)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This will be used by Anaconda to allow root *password* logins via ssh.

Resolves: rhbz#2083269