### PR TITLE
Write commands in alphabetical order

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -305,6 +305,12 @@ class KickstartHandler(KickstartObject):
         return retval
 
     def _insertSorted(self, lst, obj):
+        def cmdName(cmdObj):
+            if cmdObj.__class__.__name__.find("_") != -1:
+                return cmdObj.__class__.__name__.split("_", 1)[1]
+            else:
+                return cmdObj.__class__.__name__
+
         length = len(lst)
         i = 0
 
@@ -312,12 +318,12 @@ class KickstartHandler(KickstartObject):
             # If the two classes have the same name, it's because we are
             # overriding an existing class with one from a later kickstart
             # version, so remove the old one in favor of the new one.
-            if obj.__class__.__name__ > lst[i].__class__.__name__:
+            if cmdName(obj) > cmdName(lst[i]):
                 i += 1
-            elif obj.__class__.__name__ == lst[i].__class__.__name__:
+            elif cmdName(obj) == cmdName(lst[i]):
                 lst[i] = obj
                 return
-            elif obj.__class__.__name__ < lst[i].__class__.__name__:
+            elif cmdName(obj) < cmdName(lst[i]):
                 break
 
         if i >= length:

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,6 +16,9 @@ from pykickstart.commands.zfcp import F14_ZFCPData
 from pykickstart.commands.autopart import F23_AutoPart
 from pykickstart.commands.btrfs import F17_BTRFS, F23_BTRFS, F23_BTRFSData
 from pykickstart.commands.cdrom import FC3_Cdrom
+from pykickstart.commands.rootpw import F37_RootPw
+from pykickstart.commands.user import F24_User
+from pykickstart.commands.firewall import F28_Firewall
 from pykickstart.base import BaseData, BaseHandler, DeprecatedCommand, KickstartCommand
 from pykickstart.base import KickstartHandler, RemovedCommand
 
@@ -184,6 +187,20 @@ class KickstartHandler_TestCase(unittest.TestCase):
         parser = KickstartParser(handler)
         parser.readKickstartFromString("cdrom")
         self.assertEqual(str(handler), "# Use CDROM installation media\ncdrom\n")
+
+class KickstartHandlerOrder_TestCase(unittest.TestCase):
+    def runTest(self):
+        handler = KickstartHandler()
+        self.assertEqual(str(handler), "")
+
+        handler = KickstartHandler()
+        handler.registerCommand('user', F24_User)
+        handler.registerCommand('firewall', F28_Firewall)
+        handler.registerCommand('rootpw', F37_RootPw)
+
+        # Test the order in the internal _writeOrder lists
+        lst = [cls.__class__.__name__ for cls in handler._writeOrder[0]]
+        self.assertEqual(lst, ["F28_Firewall", "F37_RootPw", "F24_User"])
 
 class HandlerRegisterCommands_TestCase(unittest.TestCase):
     def runTest(self):


### PR DESCRIPTION
When a kickstart is output the commands are grouped by write priority,
then alphabetical within the group. This isn't how it was actually
working -- it was using the full class name with release prefixes (eg.
F37_) so a newer command would sort before older commands, as seen with
the recent rootpw change.

This changes the insert to compare based on the command name portion of
the class name, without the prefix. This will change the order of some
things -- but in the future the output will be in stable alphabetical
order.

Resolves: rhbz#2096871