### PR TITLE
Add support for automatic LUN Scan

### DIFF
--- a/pykickstart/handlers/rhel8.py
+++ b/pykickstart/handlers/rhel8.py
@@ -96,7 +96,7 @@ class RHEL8Handler(BaseHandler):
         "volgroup": commands.volgroup.RHEL8_VolGroup,
         "xconfig": commands.xconfig.F14_XConfig,
         "zerombr": commands.zerombr.F9_ZeroMbr,
-        "zfcp": commands.zfcp.F14_ZFCP,
+        "zfcp": commands.zfcp.RHEL8_ZFCP,
         "zipl": commands.zipl.RHEL8_Zipl,
     }
 
@@ -122,5 +122,5 @@ class RHEL8Handler(BaseHandler):
         "SshKeyData": commands.sshkey.F22_SshKeyData,
         "UserData": commands.user.F19_UserData,
         "VolGroupData": commands.volgroup.RHEL8_VolGroupData,
-        "ZFCPData": commands.zfcp.F14_ZFCPData,
+        "ZFCPData": commands.zfcp.RHEL8_ZFCPData,
     }

--- a/tests/commands/zfcp.py
+++ b/tests/commands/zfcp.py
@@ -131,5 +131,17 @@ class F14_TestCase(F12_TestCase):
         self.assert_removed("zfcp", "--scsiid")
         self.assert_removed("zfcp", "--scsilun")
 
+class RHEL8_TestCase(F14_TestCase):
+    def runTest(self):
+        F14_TestCase.runTest(self)
+
+        # pass
+        self.assert_parse("zfcp --devnum=1", "zfcp --devnum=1\n")
+
+        # fail
+        self.assert_parse_error("zfcp --wwpn=2 --fcplun=3")
+        self.assert_parse_error("zfcp --devnum=1 --wwpn=2")
+        self.assert_parse_error("zfcp --devnum=1 --fcplun=3")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If automatic LUN scanning is available, it is sufficient to specify
an FCP device number with `zfcp --devnum=<device_number>`.

(cherry picked from commit 28e808a24c57666792249337185f5cb35c903b4c)

Signed-off-by: Brian C. Lane <bcl@rehat.com>

Replaced F37 references from master with RHEL8.

Resolves: rhbz#1497088