### PR TITLE
Add --hibernation option to AutoPart

### DIFF
--- a/pykickstart/handlers/f38.py
+++ b/pykickstart/handlers/f38.py
@@ -28,7 +28,7 @@ class F38Handler(BaseHandler):
         "auth": commands.authconfig.F35_Authconfig, # RemovedCommand
         "authconfig": commands.authconfig.F35_Authconfig, # RemovedCommand
         "authselect": commands.authselect.F28_Authselect,
-        "autopart": commands.autopart.F29_AutoPart,
+        "autopart": commands.autopart.F38_AutoPart,
         "autostep": commands.autostep.F34_AutoStep,
         "bootloader": commands.bootloader.F34_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,

--- a/tests/commands/autopart.py
+++ b/tests/commands/autopart.py
@@ -348,5 +348,12 @@ class RHEL8_TestCase(F29_TestCase):
         F29_TestCase.runTest(self)
         self.assert_parse_error("autopart --type=btrfs")
 
+class F38_TestCase(F29_TestCase):
+    def runTest(self):
+        F29_TestCase.runTest(self)
+        self.assert_parse("autopart --hibernation",
+                          "autopart --hibernation\n")
+        self.assert_parse_error("autopart --hibernation --noswap")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add F38_AutoPart class with a new Kickstart flag that creates a swap partition for hibernation.

Installer implementation: https://github.com/rhinstaller/anaconda/pull/4275