### PR TITLE
sshkey: Escapes quotes in the ssh key

### DIFF
--- a/pykickstart/commands/sshkey.py
+++ b/pykickstart/commands/sshkey.py
@@ -58,6 +58,17 @@ class F22_SshKeyData(BaseData):
         retval += ' "%s"' % self.key
         return retval
 
+class F38_SshKeyData(F22_SshKeyData):
+    removedKeywords = BaseData.removedKeywords
+    removedAttrs = BaseData.removedAttrs
+
+    def _getArgsAsStr(self):
+        retval = ""
+
+        retval += " --username=%s" % self.username
+        retval += ' "%s"' % self.key.replace('"', r'\"')
+        return retval
+
 class F22_SshKey(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs

--- a/pykickstart/handlers/f38.py
+++ b/pykickstart/handlers/f38.py
@@ -117,7 +117,7 @@ class F38Handler(BaseHandler):
         "RepoData": commands.repo.F30_RepoData,
         "SnapshotData": commands.snapshot.F26_SnapshotData,
         "SshPwData": commands.sshpw.F24_SshPwData,
-        "SshKeyData": commands.sshkey.F22_SshKeyData,
+        "SshKeyData": commands.sshkey.F38_SshKeyData,
         "UserData": commands.user.F19_UserData,
         "VolGroupData": commands.volgroup.F21_VolGroupData,
         "ZFCPData": commands.zfcp.F37_ZFCPData,

--- a/tests/commands/sshkey.py
+++ b/tests/commands/sshkey.py
@@ -87,5 +87,13 @@ sshkey --username=otherguy 'this is the key'""")
 sshkey --username=someguy 'this is the key'
 sshkey --username=someguy 'this is the key'""", KickstartParseWarning)
 
+class F38_Quotes_TestCase(CommandTest):
+    key='\\"/usr/bin/rrsync /home/user/public_html/\\",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJGDmFSzIWSvnFYhExf+FbzSiZxsoohJdrKlmPKQhdts8nSg5PH7jyG5X+w6RgWhSetlD3WouKoo3zFOR5nCYq4= bcl@notae.us'
+
+    def runTest(self):
+        # pass
+        self.assert_parse('sshkey --username=root "%s"' % self.key, 'sshkey --username=root "%s"\n' % self.key)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This allows spaces and quotes to be used in the options section of the
ssh key, eg:

    sshkey --username=root "from=\"192.168.1.1\" ssh-rsa ..."
    sshkey --username=user "\"/usr/bin/rrsync /home/user/public_html/\",no-port-forwarding ssh-rsa ..."

Resolves: rhbz#2117734