### PR TITLE
Fix syntax of a code sample

### DIFF
--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -155,7 +155,7 @@ class F18_Timezone(FC6_Timezone):
                         package to be automatically installed then use ``-chrony``
                         in package selection. For example::
 
-                        ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
+                        timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague
                         """)
         return op
 
@@ -253,7 +253,7 @@ class RHEL7_Timezone(F18_Timezone):
                         package to be automatically installed then use ``-chrony``
                         in package selection. For example::
 
-                        ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
+                        timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague
                         """)
         return op
 
@@ -354,7 +354,7 @@ class F25_Timezone(F23_Timezone):
                         package to be automatically installed then use ``-chrony``
                         in package selection. For example::
 
-                        ``timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague``
+                        timezone --ntpservers=ntp.cesnet.cz,tik.nic.cz Europe/Prague
                         """)
         return op
 


### PR DESCRIPTION
With reStructuredText the :: after example already start a code block.  This makes the backticks redundant and are shown in the rendered documentation.

https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#timezone
![Screen Shot 2022-09-15 at 12 11 53](https://user-images.githubusercontent.com/155810/190378395-b1689224-df2a-4e93-9a4c-44bcd2b66806.png)
