### PR TITLE
deps: Move dependencies into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-# Installs all extras (for testing and documentation) in pykickstart.
-.[docs,test]
+Sphinx
+coveralls
+coverage
+pocketlint
+pylint

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,6 @@ setup(cmdclass={"install_scripts": install_scripts},
       url='https://fedoraproject.org/wiki/pykickstart',
       license='COPYING',
       install_requires=['requests'],
-      extras_require={
-          "docs": ['Sphinx'],
-          "test": ['coveralls', 'coverage', 'pocketlint', 'pylint']},
       # These are installed by install_scripts() without their filename extensions
       scripts=['tools/ksvalidator.py', 'tools/ksflatten.py', 'tools/ksverdiff.py', 'tools/ksshell.py'],
       packages=['pykickstart', 'pykickstart.commands', 'pykickstart.handlers'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 envlist = py36, py37, py38, py39, py310, py311, mypy
 
 [testenv]
-deps =
-    .[docs,test]
-    py311: astroid>=2.12
+deps = -rrequirements.txt
 setenv =
         COVERAGE=coverage
         SPHINXAPIDOC=sphinx-apidoc


### PR DESCRIPTION
Something changed and tox with python 3.7 and later no longer installs the deps from setup.py using "deps = .[docs, test]" so fall back to using "deps = -rrequirements.txt" instead.

This should fix the PR test runs.