### PR TITLE
Fix the coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ endif
 	@echo "*** Running unittests with coverage ***"
 	PYTHONPATH=. $(COVERAGE) run -p --branch --source=pykickstart,tools -m unittest -v $(tests)
 	-$(COVERAGE) combine
-	-$(COVERAGE) report -m --include="pykickstart/*,tools/*" | tee coverage-report.log
+	-$(COVERAGE) report -m | tee coverage-report.log
 
 clean:
 	-rm *.tar.gz pykickstart/*.pyc pykickstart/*/*.pyc tests/*.pyc tests/*/*.pyc *log .coverage pykickstart.spec


### PR DESCRIPTION
The coverage report says "No data to report" after running the unit tests. It can be fixed with the removal of the `--include` option. Since the coverage is collected with the `--source=pykickstart,tools` option, there are no other data anyway.