### PR TITLE
Improve local rpm build experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ GPGKEY ?= $(shell git config user.signingkey)
 WEBLATE_REPO = git@github.com:pykickstart/weblate
 WEBLATE_BRANCH ?= $(shell git branch --show-current)
 
+SPECFILE ?= pykickstart.spec
+
 tests := $(wildcard tests/*py tests/commands/*py tests/tools/*py)
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ scratch: docs
 rc-release: scratch-bumpver scratch pykickstart.spec
 	if [ -z "$(SPECFILE)" ]; then echo "SPECFILE must be set for this target" ; exit 1; fi
 	mock -r $(MOCKCHROOT) --scrub all || exit 1
-	mock -r $(MOCKCHROOT) --buildsrpm  --spec $(SPECFILE) --sources . --resultdir $(shell pwd) || exit 1
-	mock -r $(MOCKCHROOT) --rebuild *src.rpm --resultdir $(shell pwd)  || exit 1
+	mock -r $(MOCKCHROOT) --without signed --buildsrpm  --spec $(SPECFILE) --sources . --resultdir $(shell pwd) || exit 1
+	mock -r $(MOCKCHROOT) --without signed --rebuild *src.rpm --resultdir $(shell pwd)  || exit 1
 
 .PHONY: check clean install tag archive local docs release sign

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ scratch: docs
 	@rm -rf pykickstart-$(VERSION).tar.gz
 	@rm -rf /tmp/pykickstart-$(VERSION) /tmp/pykickstart
 	@dir=$$PWD; cp -a $$dir /tmp/pykickstart-$(VERSION)
+	@cp /tmp/pykickstart-$(VERSION)/docs/_build/text/kickstart-docs.txt /tmp/pykickstart-$(VERSION)/docs
 	@cd /tmp/pykickstart-$(VERSION) ; $(PYTHON) setup.py -q sdist
 	@cp /tmp/pykickstart-$(VERSION)/dist/pykickstart-$(VERSION).tar.gz .
 	@rm -rf /tmp/pykickstart-$(VERSION)

--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -2,6 +2,7 @@
 # at the moment, but can run locally.  To build and run tests, do:
 #     rpmbuild -ba --with runtests pykickstart.spec
 %bcond_with runtests
+%bcond_with signed
 
 Name:      pykickstart
 Version:   %%VERSION%%
@@ -10,7 +11,9 @@ License:   GPLv2 and MIT
 Summary:   Python utilities for manipulating kickstart files.
 Url:       http://fedoraproject.org/wiki/pykickstart
 Source0:   https://github.com/pykickstart/%{name}/releases/download/r%{version}/%{name}-%{version}.tar.gz
+%if %{with signed}
 Source1:   https://github.com/pykickstart/%{name}/releases/download/r%{version}/%{name}-%{version}.tar.gz.asc
+%endif
 
 BuildArch: noarch
 

--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -75,3 +75,5 @@ make PYTHON=%{__python3} test
 %doc docs/kickstart-docs.txt
 %{python3_sitelib}/pykickstart
 %{python3_sitelib}/pykickstart*.egg-info
+
+%changelog


### PR DESCRIPTION
This will allow us to do `make rc-release` and get rpm files of pykickstart. Otherwise it's pretty hard to do when you don't know the project so much.