### PR TITLE
displaymode: Update description to describe behavior

### DIFF
--- a/pykickstart/commands/displaymode.py
+++ b/pykickstart/commands/displaymode.py
@@ -68,10 +68,12 @@ class FC3_DisplayMode(KickstartCommand):
     def _getParser(self):
         op = KSOptionParser(prog="graphical|text|cmdline", version=FC3,
                             description="""
-                            Controls which display mode will be used during
-                            installation. If ``cmdline`` is chosen all required
-                            installation options must be configured via kickstart
-                            otherwise the installation will fail.""")
+                            Controls which display mode will be used for the
+                            installation and for the installed system. If ``text``
+                            or ``cmdline`` is chosen the system will boot in text
+                            mode. And when ``cmdline`` is used all required installation
+                            options must be configured via kickstart, otherwise the 
+                            installation will fail.""")
         return op
 
 class F26_DisplayMode(FC3_DisplayMode):


### PR DESCRIPTION
The displaymode commands (text, cmdline, graphical) control the mode during the installation, and the mode that the system will boot into by default. This updates the description to correctly reflect that behavior.