### PR TITLE
Fedora uses repo name "fedora-updates"

### DIFF
--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -230,6 +230,7 @@ class FC6_Repo(KickstartCommand):
                             of repos in this directory changes from release to
                             release and cannot be listed here. There will
                             likely always be a repo named "updates".
+                            Fedora uses the name "fedora-updates" instead.
 
                             Note: If you want to enable one of the repos in
                             /etc/anaconda.repos.d that is disabled by default


### PR DESCRIPTION
Current Fedora versions use repo name "fedora-updates" instead of "updates". It should be mentioned in the documentation because it is difficult to check /etc/anaconda.repos.d/ on an installation image (need to boot into rescue mode, for example). Fedora changes the name from "updates" to "fedora-updates" some releases ago (before Fedora 35 ?) without notice in the release notes.