### PR TITLE
realm: switch from pipes.quote() to shlex.quote()

### DIFF
--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -23,7 +23,6 @@ from pykickstart.options import KSOptionParser
 from pykickstart.errors import KickstartParseError
 
 import getopt
-import pipes
 import shlex
 
 from pykickstart.i18n import _
@@ -81,7 +80,7 @@ class F19_Realm(KickstartCommand):
     def _getCommandsAsStrings(self):
         commands = []
         if self.join_args:
-            args = [pipes.quote(arg) for arg in self.join_args]
+            args = [shlex.quote(arg) for arg in self.join_args]
             commands.append("realm join " + " ".join(args))
         return commands
 


### PR DESCRIPTION
The 'pipes' module was marked deprecated in Python 3.11, slated for removal in Python 3.13 [1]. The only bit of it used was `pipes.quote()`, which can be easily replaced by `shlex.quote()`, as it is also implemented in the 'pipes' module.

[1] https://peps.python.org/pep-0594/#pipes