### PR TITLE
Deprecate the nvdimm kickstart command

### DIFF
--- a/pykickstart/commands/nvdimm.py
+++ b/pykickstart/commands/nvdimm.py
@@ -19,12 +19,12 @@
 #
 
 import warnings
-from pykickstart.base import BaseData, KickstartCommand
+from pykickstart.base import BaseData, KickstartCommand, DeprecatedCommand
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser, commaSplit
 from pykickstart.constants import NVDIMM_MODE_SECTOR, NVDIMM_ACTION_RECONFIGURE, \
     NVDIMM_ACTION_USE
-from pykickstart.version import F28
+from pykickstart.version import F28, F40, versionToLongString
 
 from pykickstart.i18n import _
 
@@ -78,13 +78,12 @@ class F28_Nvdimm(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
 
+    validActions = [NVDIMM_ACTION_RECONFIGURE, NVDIMM_ACTION_USE]
+    validModes = [NVDIMM_MODE_SECTOR]
+
     def __init__(self, writePriority=80, *args, **kwargs):
         KickstartCommand.__init__(self, writePriority, *args, **kwargs)
-
         self.actionList = kwargs.get("actionList", [])
-        self.validActions = [NVDIMM_ACTION_RECONFIGURE, NVDIMM_ACTION_USE]
-        self.validModes = [NVDIMM_MODE_SECTOR]
-
         self.op = self._getParser()
 
     def __str__(self):
@@ -170,3 +169,13 @@ class F28_Nvdimm(KickstartCommand):
     @property
     def dataClass(self):
         return self.handler.NvdimmData
+
+
+class F40_Nvdimm(DeprecatedCommand, F28_Nvdimm):
+    def __init__(self):  # pylint: disable=super-init-not-called
+        DeprecatedCommand.__init__(self)
+
+    def _getParser(self):
+        op = F28_Nvdimm._getParser(self)
+        op.description += "\n\n.. deprecated:: %s" % versionToLongString(F40)
+        return op

--- a/pykickstart/handlers/f40.py
+++ b/pykickstart/handlers/f40.py
@@ -64,7 +64,7 @@ class F40Handler(BaseHandler):
         "multipath": commands.multipath.F34_MultiPath,
         "network": commands.network.F39_Network,
         "nfs": commands.nfs.FC6_NFS,
-        "nvdimm": commands.nvdimm.F28_Nvdimm,
+        "nvdimm": commands.nvdimm.F40_Nvdimm,
         "timesource": commands.timesource.F33_Timesource,
         "ostreecontainer": commands.ostreecontainer.F38_OSTreeContainer,
         "ostreesetup": commands.ostreesetup.F38_OSTreeSetup,

--- a/tests/commands/nvdimm.py
+++ b/tests/commands/nvdimm.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+
+from pykickstart.base import DeprecatedCommand
 from tests.baseclass import CommandTest
 
 
@@ -54,6 +56,16 @@ class F28_TestCase(CommandTest):
         self.assert_parse_error("nvdimm use --namespace=namespace0.0 --blockdevs=pmem0s1 --mode=sector")
         # Only --namespace is allowed for reconfigure action
         self.assert_parse_error("nvdimm reconfigure --blockdev=pmem0s1 --mode=sector")
+
+
+class F40_TestCase(F28_TestCase):
+    def runTest(self):
+        # make sure we've been deprecated
+        parser = self.getParser("nvdimm")
+        self.assertTrue(issubclass(parser.__class__, DeprecatedCommand))
+
+        # make sure we are still able to parse it
+        self.assert_parse("nvdimm use --namespace=whatever")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
All additional support for NVDIMM namespaces is being deprecated and removed from the Anaconda installer.

See: https://github.com/rhinstaller/anaconda/pull/5353