### PR TITLE
Backport ostreecontainer to RHEL9

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -60,6 +60,7 @@ class KickstartCommand(KickstartObject):
     """The base class for all kickstart commands.  This is an abstract class."""
     removedKeywords = []
     removedAttrs = []
+    conflictingCommands = []
 
     def __init__(self, writePriority=0, *args, **kwargs):
         """Create a new KickstartCommand instance.  This method must be
@@ -187,6 +188,15 @@ class KickstartCommand(KickstartObject):
     def _setToObj(self, namespace, obj):
         warnings.warn("_setToObj has been renamed to set_to_obj.  The old name will be removed in a future release.", PendingDeprecationWarning, stacklevel=2)
         self.set_to_obj(namespace, obj)
+
+    # Check for conflicting commands and raise an error
+    def _checkConflictingCommands(self, msg):
+        for cmd in self.conflictingCommands:
+            if not hasattr(self.handler, cmd) or not getattr(self.handler, cmd).seen:
+                continue
+
+            raise KickstartParseError(msg % cmd, lineno=self.lineno)
+
 
 class DeprecatedCommand(KickstartCommand):
     """Specify that a command is deprecated and no longer has any function.

--- a/pykickstart/commands/__init__.py
+++ b/pykickstart/commands/__init__.py
@@ -62,6 +62,7 @@ from pykickstart.commands import (
     nfs,
     nvdimm,
     timesource,
+    ostreecontainer,
     ostreesetup,
     partition,
     raid,

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -181,17 +181,6 @@ class RHEL6_AutoPart(F12_AutoPart):
                         filesystem.""")
         return op
 
-    def parse(self, args):
-        # call the overriden command to do its job first
-        retval = F12_AutoPart.parse(self, args)
-
-        # Using autopart together with other partitioning command such as
-        # part/partition, raid, logvol or volgroup can lead to hard to debug
-        # behavior that might among other result into an unbootable system.
-        self._checkConflictingCommands(_("The %s and autopart commands can't be used at the same time"))
-        return retval
-
-
 class F16_AutoPart(F12_AutoPart):
     removedKeywords = F12_AutoPart.removedKeywords
     removedAttrs = F12_AutoPart.removedAttrs
@@ -316,16 +305,6 @@ class F20_AutoPart(F18_AutoPart):
     def __init__(self, writePriority=100, *args, **kwargs):
         F18_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
         self.typeMap["thinp"] = AUTOPART_TYPE_LVM_THINP
-
-    def parse(self, args):
-        # call the overriden command to do its job first
-        retval = F18_AutoPart.parse(self, args)
-
-        # Using autopart together with other partitioning command such as
-        # part/partition, raid, logvol or volgroup can lead to hard to debug
-        # behavior that might among other result into an unbootable system.
-        self._checkConflictingCommands(_("The %s and autopart commands can't be used at the same time"))
-        return retval
 
     def _getParser(self):
         "Only necessary for the type change documentation"

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -54,11 +54,8 @@ class FC3_AutoPart(KickstartCommand):
                             Automatically create partitions -- a root (``/``) partition,
                             a swap partition, and an appropriate boot partition
                             for the architecture. On large enough drives, this
-                            will also create a /home partition.
-
-                            The ``autopart`` command can't be used with the logvol,
-                            part/partition, raid, reqpart, or volgroup in the same
-                            kickstart file.""", version=FC3)
+                            will also create a /home partition.""",
+                              version=FC3, conflicts=self.conflictingCommands)
 
 class F9_AutoPart(FC3_AutoPart):
     removedKeywords = FC3_AutoPart.removedKeywords
@@ -157,6 +154,7 @@ class F12_AutoPart(F9_AutoPart):
 class RHEL6_AutoPart(F12_AutoPart):
     removedKeywords = F12_AutoPart.removedKeywords
     removedAttrs = F12_AutoPart.removedAttrs
+    conflictingCommands = ["partition", "raid", "volgroup", "logvol"]
 
     def __init__(self, writePriority=100, *args, **kwargs):
         F12_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
@@ -190,27 +188,7 @@ class RHEL6_AutoPart(F12_AutoPart):
         # Using autopart together with other partitioning command such as
         # part/partition, raid, logvol or volgroup can lead to hard to debug
         # behavior that might among other result into an unbootable system.
-        #
-        # Therefore if any of those commands is detected in the same kickstart
-        # together with autopart, an error is raised and installation is
-        # aborted.
-        conflicting_command = ""
-
-        # seen indicates that the corresponding
-        # command has been seen in kickstart
-        if self.handler.partition.seen:
-            conflicting_command = "part/partition"
-        elif self.handler.raid.seen:
-            conflicting_command = "raid"
-        elif self.handler.volgroup.seen:
-            conflicting_command = "volgroup"
-        elif self.handler.logvol.seen:
-            conflicting_command = "logvol"
-
-        if conflicting_command:
-            # allow for translation of the error message
-            errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The %s and autopart commands can't be used at the same time"))
         return retval
 
 
@@ -333,6 +311,8 @@ class F18_AutoPart(F17_AutoPart):
         return op
 
 class F20_AutoPart(F18_AutoPart):
+    conflictingCommands = ["partition", "raid", "volgroup", "logvol"]
+
     def __init__(self, writePriority=100, *args, **kwargs):
         F18_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
         self.typeMap["thinp"] = AUTOPART_TYPE_LVM_THINP
@@ -344,29 +324,7 @@ class F20_AutoPart(F18_AutoPart):
         # Using autopart together with other partitioning command such as
         # part/partition, raid, logvol or volgroup can lead to hard to debug
         # behavior that might among other result into an unbootable system.
-        #
-        # Therefore if any of those commands is detected in the same kickstart
-        # together with autopart, an error is raised and installation is
-        # aborted.
-        conflicting_command = ""
-
-        # seen indicates that the corresponding
-        # command has been seen in kickstart
-        if self.handler.partition.seen:
-            conflicting_command = "part/partition"
-        elif self.handler.raid.seen:
-            conflicting_command = "raid"
-        elif self.handler.volgroup.seen:
-            conflicting_command = "volgroup"
-        elif self.handler.logvol.seen:
-            conflicting_command = "logvol"
-        elif hasattr(self.handler, "mount") and self.handler.mount.seen:
-            conflicting_command = "mount"
-
-        if conflicting_command:
-            # allow for translation of the error message
-            errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The %s and autopart commands can't be used at the same time"))
         return retval
 
     def _getParser(self):
@@ -425,22 +383,10 @@ class F21_AutoPart(F20_AutoPart):
         return retval
 
 class F23_AutoPart(F21_AutoPart):
-    def parse(self, args):
-        # call the overriden command to do its job first
-        retval = F21_AutoPart.parse(self, args)
-
-        conflicting_command = ""
-        if hasattr(self.handler, "reqpart") and self.handler.reqpart.seen:
-            conflicting_command = "reqpart"
-
-        if conflicting_command:
-            # allow for translation of the error message
-            errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
-
-        return retval
+    conflictingCommands = ["partition", "raid", "volgroup", "logvol", "reqpart"]
 
 class RHEL7_AutoPart(F21_AutoPart):
+    conflictingCommands = ["partition", "raid", "volgroup", "logvol", "reqpart"]
 
     def __init__(self, writePriority=100, *args, **kwargs):
         F21_AutoPart.__init__(self, writePriority=writePriority, *args, **kwargs)
@@ -465,21 +411,6 @@ class RHEL7_AutoPart(F21_AutoPart):
                         version=RHEL7, help="""
                         Do not create a /home partition.""")
         return op
-
-    def parse(self, args):
-        # call the overriden command to do its job first
-        retval = F21_AutoPart.parse(self, args)
-
-        conflicting_command = ""
-        if hasattr(self.handler, "reqpart") and self.handler.reqpart.seen:
-            conflicting_command = "reqpart"
-
-        if conflicting_command:
-            # allow for translation of the error message
-            errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
-
-        return retval
 
 class F26_AutoPart(F23_AutoPart):
     removedKeywords = F23_AutoPart.removedKeywords

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -620,9 +620,6 @@ class RHEL6_LogVol(F12_LogVol):
     def parse(self, args):
         # call the overriden method
         retval = F12_LogVol.parse(self, args)
-        # the logvol command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The logvol and %s commands can't be used at the same time"))
 
         if retval.thin_volume and retval.thin_pool:
             errorMsg = _("--thin and --thinpool cannot both be specified for "
@@ -747,10 +744,6 @@ class F20_LogVol(F18_LogVol):
            not retval.thin_pool:
             err = _("--chunksize and --metadatasize are for thin pools only")
             raise KickstartParseError(err, lineno=self.lineno)
-
-        # the logvol command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The logvol and %s commands can't be used at the same time"))
 
         if not retval.preexist and not retval.percent and not retval.size and not retval.recommended and not retval.hibernation:
             errorMsg = _("No size given for logical volume. Use one of --useexisting, --noformat, --size, --percent, or --hibernation.")

--- a/pykickstart/commands/mount.py
+++ b/pykickstart/commands/mount.py
@@ -144,7 +144,6 @@ class F27_Mount(KickstartCommand):
         return op
 
     def parse(self, args):
-        self._checkConflictingCommands(_("The mount and %s commands can't be used at the same time"))
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if extra:

--- a/pykickstart/commands/ostreecontainer.py
+++ b/pykickstart/commands/ostreecontainer.py
@@ -22,6 +22,7 @@ from pykickstart.options import KSOptionParser
 class RHEL9_OSTreeContainer(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
+    conflictingCommands = ["ostreesetup"]
 
     def __init__(self, *args, **kwargs):
         KickstartCommand.__init__(self, *args, **kwargs)
@@ -64,7 +65,7 @@ class RHEL9_OSTreeContainer(KickstartCommand):
                             for more information about OSTree.
 
                             **Experimental. Use on your own risk.**
-                            """, version=RHEL9)
+                            """, version=RHEL9, conflicts=self.conflictingCommands)
         # Rename the osname to stateroot and set default as proposed by
         # https://github.com/ostreedev/ostree/issues/2794
         op.add_argument("--stateroot", version=RHEL9, help="""

--- a/pykickstart/commands/ostreecontainer.py
+++ b/pykickstart/commands/ostreecontainer.py
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2023  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pykickstart.version import RHEL9
+from pykickstart.base import KickstartCommand
+from pykickstart.options import KSOptionParser
+
+class RHEL9_OSTreeContainer(KickstartCommand):
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+
+    def __init__(self, *args, **kwargs):
+        KickstartCommand.__init__(self, *args, **kwargs)
+        self.op = self._getParser()
+        self.stateroot = kwargs.get('stateroot', None)
+        self.url = kwargs.get('url', None)
+        self.transport = kwargs.get("transport", None)
+        self.remote = kwargs.get("remote", self.stateroot)
+        self.noSignatureVerification = kwargs.get('noSignatureVerification', False)
+
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+
+        if not self.seen:
+            return retval
+
+        retval += "# OSTree container setup\n"
+        retval += "ostreecontainer %s\n" % self._getArgsAsStr()
+
+        return retval
+
+    def _getArgsAsStr(self):
+        retcmd = []
+        if self.stateroot:
+            retcmd.append('--stateroot="%s"' % self.stateroot)
+        if self.remote:
+            retcmd.append('--remote="%s"' % self.remote)
+        if self.noSignatureVerification:
+            retcmd.append('--no-signature-verification')
+        if self.transport:
+            retcmd.append('--transport="%s"' % self.transport)
+        if self.url:
+            retcmd.append('--url="%s"' % self.url)
+        return ' '.join(retcmd)
+
+    def _getParser(self):
+        op = KSOptionParser(prog="ostreecontainer", description="""
+                            Used for OSTree installations from native container. See
+                            https://coreos.github.io/rpm-ostree/container/
+                            for more information about OSTree.
+
+                            **Experimental. Use on your own risk.**
+                            """, version=RHEL9)
+        # Rename the osname to stateroot and set default as proposed by
+        # https://github.com/ostreedev/ostree/issues/2794
+        op.add_argument("--stateroot", version=RHEL9, help="""
+                        Name for the state directory, also known as "osname".
+                        Default value will be `default`.""")
+        op.add_argument("--url", required=True, version=RHEL9, help="""
+                        Name of the container image; for the `registry` transport.
+                        This would be e.g. `quay.io/exampleos/foo:latest`.""")
+        op.add_argument("--transport", version=RHEL9, help="""
+                        The transport; e.g. registry, oci, oci-archive.
+                        The default is `registry`.""")
+        op.add_argument("--remote", version=RHEL9, help="""
+                        Name of the OSTree remote.""")
+        op.add_argument("--no-signature-verification",
+                        dest="noSignatureVerification",
+                        action="store_true",
+                        version=RHEL9,
+                        help="""Disable verification via an ostree remote.""")
+        return op
+
+    def parse(self, args):
+        ns = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(ns)
+        if not self.remote:
+            self.remote = self.stateroot
+
+        return self

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -63,7 +63,7 @@ class F21_OSTreeSetup(KickstartCommand):
                             Used for OSTree installations. See
                             https://wiki.gnome.org/action/show/Projects/OSTree
                             for more information about OSTree.
-                            """, version=F21)
+                            """, version=F21, conflicts=self.conflictingCommands)
         op.add_argument("--osname", required=True, version=F21, help="""
                         Management root for OS installation.""")
         op.add_argument("--remote", version=F21, help="""
@@ -94,4 +94,6 @@ class RHEL8_OSTreeSetup(F21_OSTreeSetup):
     pass
 
 class RHEL9_OSTreeSetup(F21_OSTreeSetup):
-    pass
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+    conflictingCommands = ["ostreecontainer"]

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -35,6 +35,8 @@ class F21_OSTreeSetup(KickstartCommand):
 
     def __str__(self):
         retval = KickstartCommand.__str__(self)
+        if not self.seen:
+            return retval
 
         if self.osname:
             retval += "# OSTree setup\n"

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -571,14 +571,6 @@ class RHEL6_Partition(F12_Partition):
                         """)
         return op
 
-    def parse(self, args):
-        # first call the overriden command
-        retval = F12_Partition.parse(self, args)
-        # the part command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The part/partition and %s commands can't be used at the same time"))
-
-        return retval
 
 class F14_Partition(F12_Partition):
     removedKeywords = F12_Partition.removedKeywords
@@ -640,9 +632,6 @@ class F20_Partition(F18_Partition):
     def parse(self, args):
         # first call the overriden command
         retval = F18_Partition.parse(self, args)
-        # the part command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The part/partition and %s commands can't be used at the same time"))
 
         # when using tmpfs, grow is not suported
         if retval.fstype == "tmpfs":

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -333,7 +333,7 @@ class FC3_Partition(KickstartCommand):
                             """, epilog="""
                             If partitioning fails for any reason, diagnostic
                             messages will appear on virtual console 3.""",
-                            version=FC3)
+                            version=FC3, conflicts=self.conflictingCommands)
         op.add_argument("mntpoint", metavar="<mntpoint>", type=mountpoint, nargs=1,
                         version=FC3, help="""
                         The ``<mntpoint>`` is where the partition will be mounted
@@ -556,6 +556,7 @@ class F12_Partition(F11_Partition):
 class RHEL6_Partition(F12_Partition):
     removedKeywords = F12_Partition.removedKeywords
     removedAttrs = F12_Partition.removedAttrs
+    conflictingCommands = ["autopart"]
 
     def _getParser(self):
         op = F12_Partition._getParser(self)
@@ -575,9 +576,8 @@ class RHEL6_Partition(F12_Partition):
         retval = F12_Partition.parse(self, args)
         # the part command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
-        if self.handler.autopart.seen:
-            errorMsg = _("The part/partition and autopart commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The part/partition and %s commands can't be used at the same time"))
+
         return retval
 
 class F14_Partition(F12_Partition):
@@ -635,19 +635,14 @@ class F18_Partition(F17_Partition):
 class F20_Partition(F18_Partition):
     removedKeywords = F18_Partition.removedKeywords
     removedAttrs = F18_Partition.removedAttrs
+    conflictingCommands = ["autopart", "mount"]
 
     def parse(self, args):
         # first call the overriden command
         retval = F18_Partition.parse(self, args)
         # the part command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
-        if self.handler.autopart.seen:
-            errorMsg = _("The part/partition and autopart commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
-        # the same applies to the 'mount' command
-        if hasattr(self.handler, "mount") and self.handler.mount.seen:
-            errorMsg = _("The part/partition and mount commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The part/partition and %s commands can't be used at the same time"))
 
         # when using tmpfs, grow is not suported
         if retval.fstype == "tmpfs":

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -370,7 +370,7 @@ class FC3_Raid(KickstartCommand):
 
                                 raid / --level=1 --device=md0 raid.01 raid.02 raid.03
                                 raid /usr --level=5 --device=md1 raid.11 raid.12 raid.13
-                            """, version=FC3)
+                            """, version=FC3, conflicts=self.conflictingCommands)
         op.add_argument("mntpoint", metavar="<mntpoint>", type=mountpoint, nargs=1,
                         version=FC3, help="""
                         Location where the RAID file system is mounted. If it
@@ -622,6 +622,7 @@ class F13_Raid(F12_Raid):
 class RHEL6_Raid(F13_Raid):
     removedKeywords = F13_Raid.removedKeywords
     removedAttrs = F13_Raid.removedAttrs
+    conflictingCommands = ["autopart"]
 
     def _getParser(self):
         op = F13_Raid._getParser(self)
@@ -636,9 +637,7 @@ class RHEL6_Raid(F13_Raid):
         retval = F13_Raid.parse(self, args)
         # the raid command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
-        if self.handler.autopart.seen:
-            errorMsg = _("The raid and autopart commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The raid and %s commands can't be used at the same time"))
         return retval
 
 class F14_Raid(F13_Raid):
@@ -684,19 +683,15 @@ class F19_Raid(F18_Raid):
 class F20_Raid(F19_Raid):
     removedKeywords = F19_Raid.removedKeywords
     removedAttrs = F19_Raid.removedAttrs
+    conflictingCommands = ["autopart", "mount"]
 
     def parse(self, args):
         # first call the overriden method
         retval = F19_Raid.parse(self, args)
         # the raid command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
-        if self.handler.autopart.seen:
-            errorMsg = _("The raid and autopart commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
-        # the same applies to the 'mount' command
-        if hasattr(self.handler, "mount") and self.handler.mount.seen:
-            errorMsg = _("The raid and mount commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The raid and %s commands can't be used at the same time"))
+
         return retval
 
 class F23_Raid(F20_Raid):

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -632,14 +632,6 @@ class RHEL6_Raid(F13_Raid):
                         filesystem.""")
         return op
 
-    def parse(self, args):
-        # first call the overriden method
-        retval = F13_Raid.parse(self, args)
-        # the raid command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The raid and %s commands can't be used at the same time"))
-        return retval
-
 class F14_Raid(F13_Raid):
     removedKeywords = F13_Raid.removedKeywords
     removedAttrs = F13_Raid.removedAttrs
@@ -684,15 +676,6 @@ class F20_Raid(F19_Raid):
     removedKeywords = F19_Raid.removedKeywords
     removedAttrs = F19_Raid.removedAttrs
     conflictingCommands = ["autopart", "mount"]
-
-    def parse(self, args):
-        # first call the overriden method
-        retval = F19_Raid.parse(self, args)
-        # the raid command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The raid and %s commands can't be used at the same time"))
-
-        return retval
 
 class F23_Raid(F20_Raid):
     removedKeywords = F20_Raid.removedKeywords

--- a/pykickstart/commands/reqpart.py
+++ b/pykickstart/commands/reqpart.py
@@ -21,8 +21,6 @@ from pykickstart.version import F23
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
-from pykickstart.i18n import _
-
 class F23_ReqPart(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
@@ -73,8 +71,6 @@ class F23_ReqPart(KickstartCommand):
         return op
 
     def parse(self, args):
-        self._checkConflictingCommands(_("The reqpart and %s commands can't be used at the same time"))
-
         ns = self.op.parse_args(args=args, lineno=self.lineno)
         self.set_to_self(ns)
         self.reqpart = True

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -218,9 +218,6 @@ class F16_VolGroup(FC3_VolGroup):
         if retval.reserved_percent is not None and not 0 < retval.reserved_percent < 100:
             raise KickstartParseError("Volume group reserved space percentage must be between 1 and 99.", lineno=self.lineno)
 
-        # the volgroup command can't be used together with the autopart command
-        # due to the hard to debug behavior their combination introduces
-        self._checkConflictingCommands(_("The volgroup and %s commands can't be used at the same time"))
         return retval
 
 class F21_VolGroup(F16_VolGroup):

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -126,7 +126,7 @@ class FC3_VolGroup(KickstartCommand):
                                 part pv.01 --size 3000
                                 volgroup myvg pv.01
                                 logvol / --vgname=myvg --size=2000 --name=rootvol
-                            """, version=FC3)
+                            """, version=FC3, conflicts=self.conflictingCommands)
         op.add_argument("name", metavar="<name>", nargs="*", version=FC3, help="""
                         Name given to the volume group. The (which denotes that
                         multiple partitions can be listed) lists the identifiers
@@ -192,6 +192,8 @@ class FC3_VolGroup(KickstartCommand):
         return self.handler.VolGroupData
 
 class F16_VolGroup(FC3_VolGroup):
+    conflictingCommands = ["autopart", "mount"]
+
     def _getParser(self):
         op = FC3_VolGroup._getParser(self)
         op.add_argument("--reserved-space", dest="reserved_space", type=int,
@@ -218,13 +220,7 @@ class F16_VolGroup(FC3_VolGroup):
 
         # the volgroup command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
-        if self.handler.autopart.seen:
-            errorMsg = _("The volgroup and autopart commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
-        # the same applies to the 'mount' command
-        if hasattr(self.handler, "mount") and self.handler.mount.seen:
-            errorMsg = _("The volgroup and mount commands can't be used at the same time")
-            raise KickstartParseError(errorMsg, lineno=self.lineno)
+        self._checkConflictingCommands(_("The volgroup and %s commands can't be used at the same time"))
         return retval
 
 class F21_VolGroup(F16_VolGroup):

--- a/pykickstart/handlers/rhel9.py
+++ b/pykickstart/handlers/rhel9.py
@@ -68,6 +68,7 @@ class RHEL9Handler(BaseHandler):
         "nfs": commands.nfs.FC6_NFS,
         "nvdimm": commands.nvdimm.F28_Nvdimm,
         "timesource": commands.timesource.F33_Timesource,
+        "ostreecontainer": commands.ostreecontainer.RHEL9_OSTreeContainer,
         "ostreesetup": commands.ostreesetup.RHEL9_OSTreeSetup,
         "part": commands.partition.RHEL9_Partition,
         "partition": commands.partition.RHEL9_Partition,

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -154,6 +154,11 @@ class KSOptionParser(ArgumentParser):
         # fail fast if we forgot to add prog
         kwargs['prog'] = kwargs.pop("prog")
 
+        # Add text about conflicting commands
+        conflicts = kwargs.pop("conflicts", None)
+        if conflicts:
+            kwargs['description'] += "\n\n.. note:: ``%s`` cannot be used with the following commands: %s" % (kwargs["prog"], ", ".join(conflicts))
+
         # remove leading spaced from description and epilog.
         # fail fast if we forgot to add description
         kwargs['description'] = textwrap.dedent(kwargs.pop("description"))

--- a/tests/commands/logvol.py
+++ b/tests/commands/logvol.py
@@ -456,6 +456,10 @@ class F20_AutopartLogVol_TestCase(CommandSequenceTest):
 autopart
 logvol / --size=1024 --name=lv --vgname=vg""")
 
+        self.assert_parse_error("""
+mount /dev/sda1 /boot
+logvol / --size=1024 --name=lv --vgname=vg""")
+
 class F21_TestCase(F20_TestCase):
     def runTest(self):
         F20_TestCase.runTest(self)

--- a/tests/commands/ostreecontainer.py
+++ b/tests/commands/ostreecontainer.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+
+import unittest
+from tests.baseclass import CommandTest
+from pykickstart.commands.ostreecontainer import RHEL9_OSTreeContainer
+
+class OSTreeContainer_TestCase(unittest.TestCase):
+    def runTest(self):
+        cmd = RHEL9_OSTreeContainer()
+        self.assertEqual(cmd.noSignatureVerification, False)
+
+        # test if arguments are required
+        op = cmd._getParser()
+        for action in op._actions:
+            if '--url' in action.option_strings:
+                self.assertEqual(action.required, True)
+
+class RHEL9_TestCase(CommandTest):
+    command = "ostreecontainer"
+
+    def runTest(self):
+        # pass
+        # the stateroot has default value "default" and remote is set from stateroot if not set
+        cmdstr = "ostreecontainer --url=\"quay.io/test/test_c:stable\""
+        self.assert_parse(cmdstr, cmdstr + "\n")
+        cmdstr = "ostreecontainer --stateroot=\"fedora-silverblue\" --url=\"quay.io/test/test_c:stable\""
+        cmdstr_expected = "ostreecontainer --stateroot=\"fedora-silverblue\" --remote=\"fedora-silverblue\" --url=\"quay.io/test/test_c:stable\""
+        self.assert_parse(cmdstr, cmdstr_expected + "\n")
+        cmdstr = "ostreecontainer --stateroot=\"fedora-silverblue\" --remote=\"test-remote\" --url=\"quay.io/test/test_c:stable\""
+        self.assert_parse(cmdstr, cmdstr + "\n")
+        cmdstr = "ostreecontainer --stateroot=\"fedora-silverblue\" --remote=\"test-remote\" --no-signature-verification --url=\"quay.io/test/test_c:stable\""
+        self.assert_parse(cmdstr, cmdstr + "\n")
+        cmdstr = "ostreecontainer --stateroot=\"fedora-silverblue\" --remote=\"test-remote\" --no-signature-verification --transport=\"repository\" --url=\"quay.io/test/test_c:stable\""
+        self.assert_parse(cmdstr, cmdstr + "\n")
+
+        # fail - we have required arguments
+        self.assert_parse_error("ostreecontainer")
+        self.assert_parse_error("ostreecontainer --bacon=tasty")
+        self.assert_parse_error("ostreecontainer --os=fedora-silverblue")
+        self.assert_parse_error("ostreecontainer --stateroot=fedora-silverblue")
+        self.assert_parse_error("ostreecontainer --no-signature-verification")
+        self.assert_parse_error("ostreecontainer --remote=\"sweet\"")
+        self.assert_parse_error("ostreecontainer --transport=\"test\"")

--- a/tests/commands/ostreecontainer.py
+++ b/tests/commands/ostreecontainer.py
@@ -17,8 +17,9 @@
 #
 
 import unittest
-from tests.baseclass import CommandTest
+from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.ostreecontainer import RHEL9_OSTreeContainer
+from pykickstart.version import RHEL9
 
 class OSTreeContainer_TestCase(unittest.TestCase):
     def runTest(self):
@@ -57,3 +58,15 @@ class RHEL9_TestCase(CommandTest):
         self.assert_parse_error("ostreecontainer --no-signature-verification")
         self.assert_parse_error("ostreecontainer --remote=\"sweet\"")
         self.assert_parse_error("ostreecontainer --transport=\"test\"")
+
+class RHEL9_Conflict_TestCase(CommandSequenceTest):
+    def __init__(self, *args, **kwargs):
+        CommandSequenceTest.__init__(self, *args, **kwargs)
+        self.version = RHEL9
+
+    def runTest(self):
+        #fail - ostreecontainer and ostreesetup can't be used together
+        self.assert_parse_error("""
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core
+        ostreecontainer --url=quay.io/fedora/silverblue:stable
+        """)

--- a/tests/commands/ostreesetup.py
+++ b/tests/commands/ostreesetup.py
@@ -19,8 +19,9 @@
 #
 
 import unittest
-from tests.baseclass import CommandTest
+from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.ostreesetup import F21_OSTreeSetup
+from pykickstart.version import RHEL9
 
 class OSTreeSetup_TestCase(unittest.TestCase):
     def runTest(self):
@@ -69,6 +70,18 @@ class F21_TestCase(CommandTest):
 class RHEL7_TestCase(F21_TestCase):
     def runTest(self):
         F21_TestCase.runTest(self)
+
+class RHEL9_Conflict_TestCase(CommandSequenceTest):
+
+    def __init__(self, *args, **kwargs):
+        CommandSequenceTest.__init__(self, *args, **kwargs)
+        self.version = RHEL9
+
+    def runTest(self):
+        #fail - ostreecontainer and ostreesetup can't be used together
+        self.assert_parse_error("""
+        ostreecontainer --url=quay.io/fedora/fcos:stable
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core""")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/partition.py
+++ b/tests/commands/partition.py
@@ -288,6 +288,10 @@ class F20_Conflict_TestCase(CommandSequenceTest):
 autopart
 part / --size=1024 --fstype=ext4""")
 
+        self.assert_parse_error("""
+mount /dev/sda1 /boot
+part / --size=1024 --fstype=ext4""")
+
 class F23_TestCase(F20_TestCase):
     def runTest(self):
         F20_TestCase.runTest(self)

--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -340,6 +340,11 @@ autopart
 raid / --device=md0 --level=0 raid.01 raid.02
 """)
 
+        self.assert_parse_error("""
+mount /dev/sda1 /boot
+raid / --device=md0 --level=0 raid.01 raid.02
+""")
+
 class F23_TestCase(F19_TestCase):
     def runTest(self):
         F19_TestCase.runTest(self)

--- a/tests/commands/reqpart.py
+++ b/tests/commands/reqpart.py
@@ -18,7 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 import unittest
-from pykickstart.version import F23
+from pykickstart.version import F23, RHEL7
 from pykickstart.commands.reqpart import F23_ReqPart
 from tests.baseclass import CommandTest, CommandSequenceTest
 
@@ -48,6 +48,15 @@ class F23_AutopartReqpart_TestCase(CommandSequenceTest):
         self.assert_parse_error("""
 autopart
 reqpart""")
+
+        self.assert_parse_error("""
+mount /dev/sda1 /boot
+reqpart""")
+
+class RHEL7_AutopartReqpart_TestCase(F23_AutopartReqpart_TestCase):
+    def __init__(self, *args, **kwargs):
+        F23_AutopartReqpart_TestCase.__init__(self, *args, **kwargs)
+        self.version = RHEL7
 
 class RHEL7_TestCase(F23_TestCase):
     def runTest(self):

--- a/tests/commands/volgroup.py
+++ b/tests/commands/volgroup.py
@@ -1,8 +1,9 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.volgroup import FC3_VolGroupData, F16_VolGroupData, F21_VolGroupData
-from pykickstart.errors import KickstartParseError, KickstartParseWarning
-from pykickstart.version import FC3, F16
+from pykickstart.errors import KickstartParseWarning
+from pykickstart.version import FC3, F16, RHEL6
+
 
 class VolGroup_TestCase(unittest.TestCase):
     def runTest(self):
@@ -147,14 +148,16 @@ class F16_TestCase(FC3_TestCase):
 class RHEL6_TestCase(F16_TestCase):
     def runTest(self):
         F16_TestCase.runTest(self)
+
         # extra test coverage
         cmd = self.handler().commands[self.command]
         cmd.parse(["volgroup", "vg.02", "pv.01"])
         self.assertEqual(cmd.__str__(), "")
-        cmd.handler.autopart.seen = True
-        with self.assertRaises(KickstartParseError):
-            cmd.parse(["volgroup", "vg.02", "pv.01"])
-        cmd.handler.autopart.seen = False
+
+class RHEL6_Conflict_TestCase(F16_AutopartVolGroup_TestCase):
+    def __init__(self, *args, **kwargs):
+        F16_AutopartVolGroup_TestCase.__init__(self, *args, **kwargs)
+        self.version = RHEL6
 
 class F21_TestCase(F16_TestCase):
     def runTest(self):

--- a/tests/commands/volgroup.py
+++ b/tests/commands/volgroup.py
@@ -2,7 +2,7 @@ import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.volgroup import FC3_VolGroupData, F16_VolGroupData, F21_VolGroupData
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
-from pykickstart.version import FC3
+from pykickstart.version import FC3, F16
 
 class VolGroup_TestCase(unittest.TestCase):
     def runTest(self):
@@ -104,6 +104,21 @@ volgroup vg.02 pv.01""")
         self.assert_parse_error("""
 volgroup vg.01 pv.01
 volgroup vg.01 pv.02""", KickstartParseWarning, 'A volgroup with the name vg.01 has already been defined.')
+
+class F16_AutopartVolGroup_TestCase(CommandSequenceTest):
+    def __init__(self, *args, **kwargs):
+        CommandSequenceTest.__init__(self, *args, **kwargs)
+        self.version = F16
+
+    def runTest(self):
+        # fail - can't use both autopart and volgroup
+        self.assert_parse_error("""
+autopart
+volgroup vg.01 pv.01 --reserved-space=1""")
+
+        self.assert_parse_error("""
+mount /dev/sda1 /boot
+volgroup vg.01 pv.01 --reserved-space=1""")
 
 class F16_TestCase(FC3_TestCase):
     def runTest(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,17 @@
 [tox]
 envlist = py36, py37, py38, py39, mypy
 
+# python 3.6 supports pylint 2.13.9 which no longer works with translation-canary
+# only run the coverage/unit tests, not pylint.
+[testenv:py36]
+deps =
+    -rrequirements.txt
+setenv =
+        COVERAGE=coverage
+allowlist_externals = make
+commands =
+    make coverage
+
 [testenv]
 deps = .[docs,test]
 setenv =


### PR DESCRIPTION
Also backport the conflicting commands framework.

This replaces #461

Resolves: RHEL-17662
