### PR TITLE
Remove deprecated kickstart commands and options

### DIFF
--- a/pykickstart/commands/autostep.py
+++ b/pykickstart/commands/autostep.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, F34, versionToLongString
-from pykickstart.base import KickstartCommand, DeprecatedCommand
+from pykickstart.version import FC3, F34, versionToLongString, F40
+from pykickstart.base import KickstartCommand, DeprecatedCommand, RemovedCommand
 from pykickstart.options import KSOptionParser
 
 class FC3_AutoStep(KickstartCommand):
@@ -72,4 +72,10 @@ class F34_AutoStep(DeprecatedCommand, FC3_AutoStep):
     def _getParser(self):
         op = FC3_AutoStep._getParser(self)
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(F34)
+        return op
+
+class F40_Autostep(RemovedCommand, F34_AutoStep):
+    def _getParser(self):
+        op = F34_AutoStep._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F40)
         return op

--- a/pykickstart/commands/logging.py
+++ b/pykickstart/commands/logging.py
@@ -17,7 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC6, F34
+from pykickstart.version import FC6, F34, F40
 from pykickstart.base import KickstartCommand
 from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
@@ -101,4 +101,14 @@ class F34_Logging(FC6_Logging):
     def _getParser(self):
         op = super()._getParser()
         op.add_argument("--level", deprecated=F34)
+        return op
+
+
+class F40_Logging(F34_Logging):
+    removedKeywords = F34_Logging.removedKeywords + ["level"]
+    removedAttrs = KickstartCommand.removedAttrs + ["level"]
+
+    def _getParser(self):
+        op = F34_Logging._getParser(self)
+        op.remove_argument("--level", version=F40)
         return op

--- a/pykickstart/commands/method.py
+++ b/pykickstart/commands/method.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, F34, versionToLongString
-from pykickstart.base import KickstartCommand, DeprecatedCommand
+from pykickstart.version import FC3, F34, versionToLongString, F40
+from pykickstart.base import KickstartCommand, DeprecatedCommand, RemovedCommand
 from pykickstart.options import KSOptionParser
 
 class FC3_Method(KickstartCommand):
@@ -148,4 +148,10 @@ class F34_Method(DeprecatedCommand, F19_Method):
     def _getParser(self):
         op = F19_Method._getParser(self)
         op.description += "\n\n.. deprecated:: %s" % versionToLongString(F34)
+        return op
+
+class F40_Method(RemovedCommand, F34_Method):
+    def _getParser(self):
+        op = F34_Method._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(F40)
         return op

--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -18,7 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 from textwrap import dedent
-from pykickstart.version import versionToLongString
+from pykickstart.version import versionToLongString, F40
 from pykickstart.version import FC6, F8, F11, F13, F14, F15, F21, F27, F30, F33
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartError, KickstartParseError, KickstartParseWarning
@@ -495,3 +495,12 @@ class RHEL7_Repo(F21_Repo):
 
 class RHEL8_Repo(F30_Repo):
     pass
+
+class F40_Repo(F33_Repo):
+    removedKeywords = F33_Repo.removedKeywords + ["ignoregroups"]
+    removedAttrs = F33_Repo.removedAttrs + ["ignoregroups"]
+
+    def _getParser(self):
+        op = F33_Repo._getParser(self)
+        op.remove_argument("--ignoregroups", version=F40)
+        return op

--- a/pykickstart/handlers/f40.py
+++ b/pykickstart/handlers/f40.py
@@ -74,7 +74,7 @@ class F40Handler(BaseHandler):
         "raid": commands.raid.F29_Raid,
         "realm": commands.realm.F19_Realm,
         "reboot": commands.reboot.F23_Reboot,
-        "repo": commands.repo.F33_Repo,
+        "repo": commands.repo.F40_Repo,
         "reqpart": commands.reqpart.F23_ReqPart,
         "rescue": commands.rescue.F10_Rescue,
         "rootpw": commands.rootpw.F37_RootPw,

--- a/pykickstart/handlers/f40.py
+++ b/pykickstart/handlers/f40.py
@@ -59,7 +59,7 @@ class F40Handler(BaseHandler):
         "logging": commands.logging.F34_Logging,
         "logvol": commands.logvol.F29_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
-        "method": commands.method.F34_Method,
+        "method": commands.method.F40_Method, # RemovedCommand
         "mount": commands.mount.F27_Mount,
         "multipath": commands.multipath.F34_MultiPath,
         "network": commands.network.F39_Network,

--- a/pykickstart/handlers/f40.py
+++ b/pykickstart/handlers/f40.py
@@ -56,7 +56,7 @@ class F40Handler(BaseHandler):
         "keyboard": commands.keyboard.F18_Keyboard,
         "lang": commands.lang.F19_Lang,
         "liveimg": commands.liveimg.F19_Liveimg,
-        "logging": commands.logging.F34_Logging,
+        "logging": commands.logging.F40_Logging,
         "logvol": commands.logvol.F29_LogVol,
         "mediacheck": commands.mediacheck.FC4_MediaCheck,
         "method": commands.method.F40_Method, # RemovedCommand

--- a/pykickstart/handlers/f40.py
+++ b/pykickstart/handlers/f40.py
@@ -29,7 +29,7 @@ class F40Handler(BaseHandler):
         "authconfig": commands.authconfig.F35_Authconfig, # RemovedCommand
         "authselect": commands.authselect.F28_Authselect,
         "autopart": commands.autopart.F38_AutoPart,
-        "autostep": commands.autostep.F34_AutoStep,
+        "autostep": commands.autostep.F40_Autostep, # RemovedCommand
         "bootloader": commands.bootloader.F39_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,
         "cdrom": commands.cdrom.FC3_Cdrom,

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -201,7 +201,7 @@ class CommandTest(unittest.TestCase):
         '''Ensure that the provided option is not present in option_list'''
         parser = self.getParser(cmd)
         for action in parser.op._get_optional_actions():
-            self.assertNotEqual(action.dest, opt)
+            self.assertNotIn(opt, action.option_strings)
 
     def assert_required(self, cmd, opt):
         '''Ensure that the provided option is labelled as required in

--- a/tests/commands/autostep.py
+++ b/tests/commands/autostep.py
@@ -20,7 +20,8 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.autostep import FC3_AutoStep
-from pykickstart.base import DeprecatedCommand
+from pykickstart.base import DeprecatedCommand, RemovedCommand
+
 
 class FC3_TestCase(CommandTest):
     command = "autostep"
@@ -41,6 +42,14 @@ class F34_TestCase(FC3_TestCase):
 
         # make sure we are still able to parse it
         self.assert_parse("autostep")
+
+class F40_TestCase(F34_TestCase):
+
+    def runTest(self):
+        # make sure that autostep is removed
+        parser = self.getParser("autostep")
+        self.assertTrue(issubclass(parser.__class__, RemovedCommand))
+
 
 class AutoStep_TestCase(unittest.TestCase):
     """

--- a/tests/commands/logging.py
+++ b/tests/commands/logging.py
@@ -76,6 +76,22 @@ class F34_TestCase(CommandTest):
         with self.assertWarns(KickstartDeprecationWarning):
             self.assert_parse("logging --level=info --host=HOSTNAME --port=PORT", "logging --host=HOSTNAME --port=PORT\n")
 
+class F40_TestCase(CommandTest):
+    command = "logging"
+
+    def runTest(self):
+        # pass
+        self.assert_parse("logging", "")
+        self.assert_parse("logging --host=HOSTNAME", "logging --host=HOSTNAME\n")
+        self.assert_parse("logging --host=HOSTNAME --port=PORT", "logging --host=HOSTNAME --port=PORT\n")
+
+        # fail
+        self.assert_parse_error("logging --host")
+        self.assert_parse_error("logging --port")
+        self.assert_parse_error("logging --port=PORT")
+
+        # removed
+        self.assert_removed("logging", "--level")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/method.py
+++ b/tests/commands/method.py
@@ -21,7 +21,8 @@
 import unittest
 import copy
 from tests.baseclass import CommandTest
-from pykickstart.base import DeprecatedCommand
+from pykickstart.base import DeprecatedCommand, RemovedCommand
+
 
 class FC3_Proxy_TestCase(CommandTest):
     command = "method"
@@ -379,6 +380,13 @@ class F34_TestCase(F28_TestCase):
         # make sure we've been deprecated
         parser = self.getParser("method")
         self.assertEqual(issubclass(parser.__class__, DeprecatedCommand), True)
+
+class F40_TestCase(F34_TestCase):
+
+    def runTest(self):
+        # make sure that method is removed
+        parser = self.getParser("method")
+        self.assertTrue(issubclass(parser.__class__, RemovedCommand))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -305,7 +305,7 @@ autopart
 class F14_TestCase(F13_TestCase):
     def runTest(self):
         F13_TestCase.runTest(self)
-        self.assert_removed("raid", "bytes-per-inode")
+        self.assert_removed("raid", "--bytes-per-inode")
 
 class F15_TestCase(F14_TestCase):
     def runTest(self):

--- a/tests/commands/repo.py
+++ b/tests/commands/repo.py
@@ -114,6 +114,9 @@ class F11_TestCase(F8_TestCase):
         # run F8 test case
         F8_TestCase.runTest(self, urlRequired=urlRequired)
 
+        if "--ignoregroups" not in self.optionList:
+            return
+
         # pass
         for val in ("1", "true", "on"):
             self.assert_parse("repo --name=blah --baseurl=www.domain.com --cost=10 --excludepkgs=pkg1,pkg2 --includepkgs=pkg3,pkg4 --ignoregroups=%s" % val,
@@ -200,6 +203,11 @@ class F33_TestCase(F30_TestCase):
         self.assert_deprecated("repo", "--ignoregroups")
         with self.assertWarns(KickstartDeprecationWarning):
             self.assert_parse("repo --name=blah --baseurl=www.domain.com --ignoregroups=true")
+
+class F40_TestCase(F30_TestCase):
+    def runTest(self, urlRequired=False):
+        F30_TestCase.runTest(self, urlRequired=urlRequired)
+        self.assert_removed("repo", "--ignoregroups")
 
 
 if __name__ == "__main__":

--- a/tests/commands/vnc.py
+++ b/tests/commands/vnc.py
@@ -53,7 +53,7 @@ class F9_TestCase(FC6_TestCase):
         FC6_TestCase.runTest(self)
 
         # Ensure --connect has been removed
-        self.assert_removed("vnc", "connect")
+        self.assert_removed("vnc", "--connect")
 
         # Any --connect use should raise KickstartParseError
         self.assert_parse_error("vnc --host=HOSTNAME --connect=HOSTNAME --password=PASSWORD")


### PR DESCRIPTION
Remove the following deprecated kickstart commands and options:

- `autostep`
- `method`
- `logging --level`
- `repo --ignoregroups`

Related: INSTALLER-3849