### PR TITLE
github: Limit python version tested based on PR branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,14 @@ on:
       - rhel8-branch
       - rhel7-branch
 
+env:
+  branch_matrix:
+    master: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12.2"]
+    rhel7-branch: [3.6]
+    rhel8-branch: [3.6]
+    rhel9-branch: [3.9, "3.11", "3.12.2"]
+    rhel10-branch: ["3.12.2"]
+
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
@@ -19,7 +27,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12.0"]
+        python-version: ${{ branch_matrix[github.base_ref] }}
         include:
           - python-version: 3.6
             tox-env: py36

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,16 @@ on:
       - rhel8-branch
       - rhel7-branch
 
-env:
-  branch_matrix:
-    master: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12.2"]
-    rhel7-branch: [3.6]
-    rhel8-branch: [3.6]
-    rhel9-branch: [3.9, "3.11", "3.12.2"]
-    rhel10-branch: ["3.12.2"]
-
 jobs:
   unit-tests:
     runs-on: ubuntu-20.04
+    env:
+      branch_matrix:
+        master: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12.2"]
+        rhel7-branch: [3.6]
+        rhel8-branch: [3.6]
+        rhel9-branch: [3.9, "3.11", "3.12.2"]
+        rhel10-branch: ["3.12.2"]
     strategy:
       fail-fast: false
       max-parallel: 5


### PR DESCRIPTION
This PR attempts to limit which python versions are used to test the branches. eg. it makes no sense to test rhel8 against python 3.12 or to test rhel10-branch against anything lower than python 3.12