### PR TITLE
Add a DEFAULT_VERSION variable to version.py

### DIFF
--- a/docs/gen_sections_docs
+++ b/docs/gen_sections_docs
@@ -2,7 +2,7 @@
 import sys
 sys.path.insert(0, "../")
 from pykickstart import sections
-from pykickstart.version import returnClassForVersion, DEVEL
+from pykickstart.version import returnClassForVersion
 
 def _format_title(title, underline = '-'):
     t = title.replace('|', ' or ')
@@ -10,7 +10,7 @@ def _format_title(title, underline = '-'):
 
 if __name__ == "__main__":
     chapter = 4
-    handler = returnClassForVersion(DEVEL)
+    handler = returnClassForVersion()
     for _, section_class in sections.__dict__.items():
         # skip everything which isn't a class
         if type(section_class) is not type:

--- a/pykickstart/version.py
+++ b/pykickstart/version.py
@@ -106,6 +106,10 @@ F41 = 41000
 # This always points at the latest version and is the default.
 DEVEL = F41
 
+# On Fedora this points to DEVEL
+# On RHEL it points to the RHEL version that should be the default when no version is passed
+DEFAULT_VERSION = DEVEL
+
 # A one-to-one mapping from string representations to version numbers.
 versionMap = {
     "DEVEL": DEVEL,
@@ -181,9 +185,10 @@ def versionToLongString(version):
 
 def versionFromFile(f):
     """Given a file or URL, look for a line starting with #version= and
-       return the version number.  If no version is found, return DEVEL.
+       return the version number.  If no version is found, return the
+       default version (DEVEL on Fedora and RHELx on RHEL).
     """
-    v = DEVEL
+    v = DEFAULT_VERSION
 
     contents = load_to_str(f)
 
@@ -197,7 +202,7 @@ def versionFromFile(f):
 
     return v
 
-def returnClassForVersion(version=DEVEL):
+def returnClassForVersion(version=DEFAULT_VERSION):
     """Return the class of the syntax handler for version.  version can be
        either a string or the matching constant.  Raises KickstartVersionError
        if version does not match anything.
@@ -222,7 +227,7 @@ def returnClassForVersion(version=DEVEL):
     except:
         raise KickstartVersionError(_("Unsupported version specified: %s") % version)
 
-def makeVersion(version=DEVEL):
+def makeVersion(version=DEFAULT_VERSION):
     """Return a new instance of the syntax handler for version.  version can be
        either a string or the matching constant.  This function is useful for
        standalone programs which just need to handle a specific version of

--- a/tests/tools/ksshell.py
+++ b/tests/tools/ksshell.py
@@ -2,7 +2,7 @@ from tools import ksshell
 import unittest.mock as mock
 from unittest import TestCase
 
-from pykickstart.version import DEVEL, makeVersion
+from pykickstart.version import makeVersion
 
 
 class InvalidKSVersion_Test(TestCase):
@@ -14,7 +14,7 @@ class InvalidKSVersion_Test(TestCase):
 
 class KickstartCompleter_Test(TestCase):
     def runTest(self):
-        kshandler = makeVersion(DEVEL)
+        kshandler = makeVersion()
         self.assertIsNotNone(kshandler)
 
         # Did it add the commands, and is there at least one (part) that should be present?

--- a/tests/version.py
+++ b/tests/version.py
@@ -353,14 +353,14 @@ class versionFromFile_TestCase(CommandTest):
             os.close(fd)
             return name
 
-        # no version specified
+        # no version specified, defaults to DEFAULT_VERSION
         ks_cfg = '''
 # This is a sample kickstart file
 rootpw testing123
 cdrom
 '''
         ks_cfg = write_ks_cfg(ks_cfg)
-        self.assertEqual(versionFromFile(ks_cfg), DEVEL)
+        self.assertEqual(versionFromFile(ks_cfg), DEFAULT_VERSION)
         os.unlink(ks_cfg)
 
         # proper format ... DEVEL
@@ -385,7 +385,7 @@ cdrom
         self.assertEqual(versionFromFile(ks_cfg), RHEL3)
         os.unlink(ks_cfg)
 
-        # improper format ... fallback to DEVEL
+        # improper format ... fallback to DEFAULT_VERSION
         ks_cfg = '''
 # This is a sample kickstart file
 # version: FC3
@@ -393,7 +393,7 @@ rootpw testing123
 cdrom
 '''
         ks_cfg = write_ks_cfg(ks_cfg)
-        self.assertEqual(versionFromFile(ks_cfg), DEVEL)
+        self.assertEqual(versionFromFile(ks_cfg), DEFAULT_VERSION)
         os.unlink(ks_cfg)
 
         # unknown version specified ... raise exception

--- a/tools/ksflatten.py
+++ b/tools/ksflatten.py
@@ -24,14 +24,14 @@ import argparse
 import pykickstart
 import pykickstart.parser
 from pykickstart.i18n import _
-from pykickstart.version import DEVEL, makeVersion
+from pykickstart.version import DEFAULT_VERSION, makeVersion
 from pykickstart.errors import KickstartVersionError
 
 def parse_args(argv):
     parser = argparse.ArgumentParser()
     parser.add_argument("-c", "--config", dest="kscfg", required=True,
                         help=_("Path to kickstart config file"))
-    parser.add_argument("-v", "--version", dest="version", default=DEVEL,
+    parser.add_argument("-v", "--version", dest="version", default=DEFAULT_VERSION,
                         help=_("Kickstart version to use for interpreting config"))
     parser.add_argument("-o", "--output", dest="output",
                         help=_("Write flattened config to OUTPUT"))

--- a/tools/ksshell.py
+++ b/tools/ksshell.py
@@ -43,7 +43,7 @@ import sys
 from pykickstart.i18n import _
 from pykickstart.errors import KickstartError, KickstartVersionError
 from pykickstart.parser import KickstartParser, preprocessKickstart
-from pykickstart.version import DEVEL, makeVersion
+from pykickstart.version import DEFAULT_VERSION, makeVersion
 
 ##
 ## INTERNAL COMMANDS
@@ -153,7 +153,7 @@ def main(argv=None):
                     help=_("a basis file to use for seeding the kickstart data (optional)"))
     op.add_argument("-o", "--output", dest="output",
                     help=_("the location to write the finished kickstart file, or stdout if not given"))
-    op.add_argument("-v", "--version", dest="version", default=DEVEL,
+    op.add_argument("-v", "--version", dest="version", default=DEFAULT_VERSION,
                     help=_("version of kickstart syntax to validate against"))
 
     opts = op.parse_args(argv)

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -34,7 +34,7 @@ from pykickstart.errors import KickstartError, KickstartParseError, KickstartVer
     KickstartParseWarning, KickstartDeprecationWarning
 from pykickstart.load import is_url, load_to_file
 from pykickstart.parser import KickstartParser, preprocessKickstart
-from pykickstart.version import DEVEL, makeVersion, versionMap
+from pykickstart.version import DEFAULT_VERSION, makeVersion, versionMap
 
 def cleanup(dest, fn=None, exitval=1):
     shutil.rmtree(dest)
@@ -60,7 +60,7 @@ def main(argv):
     op.add_argument("-l", "--listversions", dest="listversions", action="store_true",
                     default=False,
                     help=_("list the available versions of kickstart syntax"))
-    op.add_argument("-v", "--version", dest="version", default=DEVEL,
+    op.add_argument("-v", "--version", dest="version", default=DEFAULT_VERSION,
                     help=_("version of kickstart syntax to validate against"))
     op.add_argument("-h", "--help", dest="help", action="store_true", default=False,
                     help=_("show this help message and exit"))


### PR DESCRIPTION
This is meant to make it easier to branch for RHEL versions where DEVEL isn't the right thing to default to. DEFAULT_VERSION isn't visible to the user, it is used to set the expected default when nothing else is passed -- usually this is the same as DEVEL. But on RHEL we can set this to be RHEL10 instead, switching it to the right parser with a 1 line change.