### PR TITLE
btrfs: Remove support for the btrfs command on RHEL10

### DIFF
--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -18,8 +18,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import F17, F23, RHEL8, versionToLongString
-from pykickstart.base import BaseData, KickstartCommand, DeprecatedCommand
+from pykickstart.version import F17, F23, RHEL8, RHEL10, versionToLongString
+from pykickstart.base import BaseData, KickstartCommand, DeprecatedCommand, RemovedCommand
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser, mountpoint
 
@@ -280,5 +280,8 @@ class RHEL8_BTRFS(DeprecatedCommand, F23_BTRFS):
 class RHEL9_BTRFS(RHEL8_BTRFS):
     pass
 
-class RHEL10_BTRFS(RHEL8_BTRFS):
-    pass
+class RHEL10_BTRFS(RemovedCommand, RHEL8_BTRFS):
+    def _getParser(self):
+        op = RHEL8_BTRFS._getParser(self)
+        op.description += "\n\n.. versionremoved:: %s" % versionToLongString(RHEL10)
+        return op

--- a/tests/commands/btrfs.py
+++ b/tests/commands/btrfs.py
@@ -20,7 +20,7 @@
 
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
-from pykickstart.base import DeprecatedCommand
+from pykickstart.base import RemovedCommand
 from pykickstart.commands.btrfs import F17_BTRFSData, F23_BTRFSData
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.version import F17
@@ -201,9 +201,9 @@ class RHEL7_TestCase(F23_TestCase):
 
 class RHEL10_TestCase(RHEL7_TestCase):
     def runTest(self):
-        # make sure we've been deprecated
+        # make sure we've been removed
         parser = self.getParser("btrfs")
-        self.assertEqual(issubclass(parser.__class__, DeprecatedCommand), True)
+        self.assertEqual(issubclass(parser.__class__, RemovedCommand), True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It was deprecated in RHEL8, time to remove it.

Resolves: RHEL-34009