### PR TITLE
Drop the MIT license

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -6,7 +6,7 @@
 Name:      pykickstart
 Version:   %%VERSION%%
 Release:   1%{?dist}
-License:   GPL-2.0-only AND MIT
+License:   GPL-2.0-only
 Summary:   Python utilities for manipulating kickstart files.
 Url:       http://fedoraproject.org/wiki/pykickstart
 Source0:   https://github.com/pykickstart/%{name}/releases/download/r%{version}/%{name}-%{version}.tar.gz


### PR DESCRIPTION
This was added because we were embedding an MIT licensed copy of OrderedSet which was switched in commit 3c592c0a1b7ff78f317e4c899eadfc51b22c9b61 to use the python3-ordered-set module. Use of that was dropped in commit ae1d16c0fa125f1252413fb47da75ff2eab70a36