### PR TITLE
commands: Add missing DeprecatedCommand class to F41_Module

### DIFF
--- a/pykickstart/commands/module.py
+++ b/pykickstart/commands/module.py
@@ -20,8 +20,8 @@
 
 from textwrap import dedent
 
-from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
+from pykickstart.base import BaseData, DeprecatedCommand, KickstartCommand
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.version import versionToLongString, F29, RHEL8, F41
 
@@ -169,14 +169,12 @@ class F31_Module(RHEL8_Module):
     removedKeywords = RHEL8_Module.removedKeywords
     removedAttrs = RHEL8_Module.removedAttrs
 
-class F41_Module(F31_Module):
+class F41_Module(DeprecatedCommand, F31_Module):
     removedKeywords = F31_Module.removedKeywords
     removedAttrs = F31_Module.removedAttrs
 
-    def parse(self, args):
-        warnings.warn("The module command is deprecated.", KickstartDeprecationWarning)
-
-        return super(F31_Module, self).parse(args)
+    def __init__(self):  # pylint: disable=super-init-not-called
+        DeprecatedCommand.__init__(self)
 
     def _getParser(self):
         op = F31_Module._getParser(self)

--- a/tests/commands/module.py
+++ b/tests/commands/module.py
@@ -21,8 +21,7 @@
 
 import unittest
 from tests.baseclass import CommandTest
-from pykickstart.errors import KickstartDeprecationWarning
-
+from pykickstart.base import DeprecatedCommand
 
 class F29_TestCase(CommandTest):
     def runTest(self):
@@ -77,9 +76,13 @@ class F31_TestCase(RHEL8_TestCase):
 
 class F41_TestCase(F31_TestCase):
     def runTest(self):
-        # F41 warns about deprecation
-        with self.assertWarns(KickstartDeprecationWarning):
-            F31_TestCase.runTest(self)
+        # make sure we've been deprecated
+        parser = self.getParser("module")
+        self.assertEqual(issubclass(parser.__class__, DeprecatedCommand), True)
+        parser = parser._getParser()
+        self.assertIsNotNone(parser)
+        self.assertTrue(parser.description.find('deprecated:: Fedora41') > -1)
+
 
 class RHEL10_TestCase(F41_TestCase):
     def runTest(self):


### PR DESCRIPTION
Also increase consistently with other deprecated commands, by calling the DeprecatedCommand init, instead of the custom parser.