### PR TITLE
pykickstart is supported on python 3.6+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = 'Python module for manipulating kickstart files'
 readme = "README.rst"
 license = { file="COPYING" }
-requires-python = ">=3.7"
+requires-python = ">=3.6"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License (GPL)",


### PR DESCRIPTION
This is to make the metadata consistent with reality (the tests all pass on python 3.6)