### PR TITLE
Mark the vnc command as deprecated on RHEL 10

### DIFF
--- a/pykickstart/commands/vnc.py
+++ b/pykickstart/commands/vnc.py
@@ -17,8 +17,8 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
-from pykickstart.version import FC3, FC6, F9
-from pykickstart.base import KickstartCommand
+from pykickstart.version import FC3, FC6, F9, RHEL10, versionToLongString
+from pykickstart.base import KickstartCommand, DeprecatedCommand
 from pykickstart.options import KSOptionParser
 
 class FC3_Vnc(KickstartCommand):
@@ -139,4 +139,13 @@ class F9_Vnc(FC6_Vnc):
     def _getParser(self):
         op = FC6_Vnc._getParser(self)
         op.remove_argument("--connect", version=F9)
+        return op
+
+class RHEL10_Vnc(DeprecatedCommand, F9_Vnc):
+    def __init__(self):  # pylint: disable=super-init-not-called
+        DeprecatedCommand.__init__(self)
+
+    def _getParser(self):
+        op = F9_Vnc._getParser(self)
+        op.description += "\nPlease use the ``inst.rdp`` boot option instead.\n\n.. deprecated:: %s" % versionToLongString(RHEL10)
         return op

--- a/pykickstart/handlers/rhel10.py
+++ b/pykickstart/handlers/rhel10.py
@@ -92,7 +92,7 @@ class RHEL10Handler(BaseHandler):
         "updates": commands.updates.F34_Updates,
         "url": commands.url.F30_Url,
         "user": commands.user.F24_User,
-        "vnc": commands.vnc.F9_Vnc,
+        "vnc": commands.vnc.RHEL10_Vnc,
         "volgroup": commands.volgroup.RHEL10_VolGroup,
         "xconfig": commands.xconfig.F14_XConfig,
         "zerombr": commands.zerombr.F9_ZeroMbr,

--- a/tests/commands/vnc.py
+++ b/tests/commands/vnc.py
@@ -1,6 +1,7 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.vnc import FC3_Vnc
+from pykickstart.base import DeprecatedCommand
 
 class Vnc_TestCase(unittest.TestCase):
     def runTest(self):
@@ -62,6 +63,12 @@ class F9_TestCase(FC6_TestCase):
         self.assert_parse_error("vnc --connect=HOSTNAME")
         self.assert_parse_error("vnc --connect")
         self.assert_parse_error("vnc --password")
+
+class RHEL10_TestCase(F9_TestCase):
+    def runTest(self):
+        # make sure the vnc command has been deprecated on RHEL 10
+        parser = self.getParser("vnc")
+        self.assertEqual(issubclass(parser.__class__, DeprecatedCommand), True)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
VNC has been replaced by the Remote Desktop protocol, which is currently controlled just by the inst.rdp boot option and does not have a corresponding
kickstart command.

Resolves: RHEL-41219