### PR TITLE
doc/versionremoved: Update VersionChange import for Sphinx 8.0.0

### DIFF
--- a/docs/versionremoved.py
+++ b/docs/versionremoved.py
@@ -11,7 +11,12 @@ try:
 except ImportError:
     versionlabel_classes = None
 
-from sphinx.directives.other import VersionChange
+# Sphinx 8.0.0 removed the alias from .directives.other
+# https://www.sphinx-doc.org/en/master/changes/8.0.html#incompatible-changes
+try:
+    from sphinx.domains.changeset import VersionChange
+except ImportError:
+    from sphinx.directives.other import VersionChange
 
 __version__ = '0.1.0'
 


### PR DESCRIPTION
The alias at sphinx.directives.other has been long deprecated and was finally removed.

Fixes #500