### PR TITLE
Add "opal-admin-passphrase" option for autopart and part commands

### DIFF
--- a/pykickstart/handlers/f41.py
+++ b/pykickstart/handlers/f41.py
@@ -28,7 +28,7 @@ class F41Handler(BaseHandler):
         "auth": commands.authconfig.F35_Authconfig, # RemovedCommand
         "authconfig": commands.authconfig.F35_Authconfig, # RemovedCommand
         "authselect": commands.authselect.F28_Authselect,
-        "autopart": commands.autopart.F38_AutoPart,
+        "autopart": commands.autopart.F41_AutoPart,
         "autostep": commands.autostep.F40_Autostep, # RemovedCommand
         "bootloader": commands.bootloader.F39_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,
@@ -68,8 +68,8 @@ class F41Handler(BaseHandler):
         "timesource": commands.timesource.F33_Timesource,
         "ostreecontainer": commands.ostreecontainer.F38_OSTreeContainer,
         "ostreesetup": commands.ostreesetup.F38_OSTreeSetup,
-        "part": commands.partition.F34_Partition,
-        "partition": commands.partition.F34_Partition,
+        "part": commands.partition.F41_Partition,
+        "partition": commands.partition.F41_Partition,
         "poweroff": commands.reboot.F23_Reboot,
         "raid": commands.raid.F29_Raid,
         "realm": commands.realm.F19_Realm,
@@ -113,7 +113,7 @@ class F41Handler(BaseHandler):
         "MultiPathData": commands.multipath.FC6_MultiPathData,
         "NetworkData": commands.network.F39_NetworkData,
         "NvdimmData": commands.nvdimm.F28_NvdimmData,
-        "PartData": commands.partition.F29_PartData,
+        "PartData": commands.partition.F41_PartData,
         "RaidData": commands.raid.F29_RaidData,
         "RepoData": commands.repo.F30_RepoData,
         "SnapshotData": commands.snapshot.F26_SnapshotData,

--- a/tests/commands/autopart.py
+++ b/tests/commands/autopart.py
@@ -360,5 +360,13 @@ class RHEL10_TestCase(F38_TestCase):
         F38_TestCase.runTest(self)
         self.assert_parse_error("autopart --type=btrfs")
 
+class F41_TestCase(F38_TestCase):
+    def runTest(self):
+        F38_TestCase.runTest(self)
+        self.assert_parse("autopart --encrypted --passphrase=\"test\" --luks-version=luks2-hw-opal --hw-passphrase=\"testhw\"",
+                          "autopart --encrypted --passphrase=\"test\" --luks-version=luks2-hw-opal --hw-passphrase=\"testhw\"\n")
+        self.assert_parse_error("autopart --passphrase=\"test\" --hw-passphrase=\"testhw\"")
+        self.assert_parse_error("autopart --encrypted --passphrase=\"test\" --luks-version=luks1 --hw-passphrase=\"testhw\"")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/partition.py
+++ b/tests/commands/partition.py
@@ -366,5 +366,15 @@ class RHEL9_TestCase(F29_TestCase):
         F29_TestCase.runTest(self)
         self.assert_parse_error("part / --fstype=btrfs")
 
+class F41_TestCase(F34_TestCase):
+    def runTest(self):
+        F34_TestCase.runTest(self)
+
+        self.assert_parse("part / --encrypted --passphrase=\"test\" --luks-version=luks2-hw-opal --hw-passphrase=\"testhw\"",
+                          "part / --encrypted --passphrase=\"test\" --luks-version=luks2-hw-opal --hw-passphrase=\"testhw\"\n")
+
+        self.assert_parse_error("part / --passphrase=\"test\" --hw-passphrase=\"testhw\"")
+        self.assert_parse_error("part / --encrypted --passphrase=\"test\" --luks-version=luks1 --hw-passphrase=\"testhw\"")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This enables support for creating LUKS HW-OPAL devices in Anaconda The feature itself is controlled by the existing "--luks-version" option, but we need the OPAL administrator passphrase from user.