### PR TITLE
Enhance %onerror section with recommendation

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -402,6 +402,9 @@ class OnErrorScriptSection(ScriptSection):
     all %onerror scripts will be run and then all %traceback scripts will be run
     afterwards.
 
+    To force %onerror execution for any error (not just fatal) use non interactive
+    installation (inst.cmdline in kernel command line options).
+
     Each %onerror script is required to be closed with a corresponding %end.
 
     .. note::


### PR DESCRIPTION
Add information that %onerror could be forced by inst.cmdline.

Resolves: RHEL-47142

Not 100% sure if we want to mention Anaconda kernel parameter in pykickstart documentation but I see this beneficial.