### PR TITLE
DeprecatedCommand: Return empty list for dataList

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -205,7 +205,7 @@ class DeprecatedCommand(KickstartCommand):
 
     def dataList(self):
         """Override the method of the deprecated command."""
-        return None
+        return []
 
     @property
     def dataClass(self):
@@ -238,7 +238,7 @@ class RemovedCommand(KickstartCommand):
 
     def dataList(self):
         """Override the method of the removed command."""
-        return None
+        return []
 
     @property
     def dataClass(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -143,12 +143,16 @@ class BaseClasses_TestCase(ParserTest):
 
         dep_cmd = TestDeprecatedCommand()
         self.assertEqual(dep_cmd.__str__(), '')
+        self.assertEqual(dep_cmd.dataList(), [])
+        self.assertEqual(dep_cmd.dataClass, None)
         with mock.patch('warnings.warn') as _warn:
             dep_cmd.parse(['test'])
             self.assertEqual(_warn.call_count, 1)
 
         removed_cmd = TestRemovedCommand()
         self.assertEqual(removed_cmd.__str__(), '')
+        self.assertEqual(removed_cmd.dataList(), [])
+        self.assertEqual(removed_cmd.dataClass, None)
         with self.assertRaises(KickstartParseError):
             removed_cmd.parse(['test'])
 


### PR DESCRIPTION
Returning None can cause callers, like anaconda, to traceback when they expect to get a list. This was revealed by the deprecated module command. Also include a test for this.