### PR TITLE
tox: Add py313 to tox and 3.12.7 to workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,14 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12.2"]
+        python-version:
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12.7"
         include:
           - python-version: 3.6
             tox-env: py36
@@ -33,7 +40,7 @@ jobs:
             tox-env: py310
           - python-version: "3.11"
             tox-env: py311
-          - python-version: "3.12.2"
+          - python-version: "3.12.7"
             tox-env: py312
     steps:
       - name: "Clone Repository"
@@ -49,7 +56,7 @@ jobs:
       - name: Run check coverage and docs
         run: tox -e ${{ matrix.tox-env }}
       - name: Coveralls
-        if: ${{ matrix.python-version == '3.12.2' }}
+        if: ${{ matrix.python-version == '3.12.7' }}
         uses: AndreMiras/coveralls-python-action@develop
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/pykickstart/commands/module.py
+++ b/pykickstart/commands/module.py
@@ -25,7 +25,6 @@ from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.version import versionToLongString, F29, RHEL8, F41
 
-import warnings
 from pykickstart.i18n import _
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312, mypy
-
-[testenv:py312]
-deps =
-    -rrequirements.txt
-    pycodestyle==2.10.0
+envlist = py36, py37, py38, py39, py310, py311, py312, py313, mypy
 
 # python 3.6 supports pylint 2.13.9 which no longer works with translation-canary
 # only run the coverage/unit tests, not pylint.


### PR DESCRIPTION
Also drop pin of pycodestyle.

pykickstart uses a private argparse function, _parse_optional, which recently changed behavior in python 3.12.7 so switch to using that version in the workflow.