### PR TITLE
Add support for inline certificates with `%certificate` section

### DIFF
--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -75,7 +75,7 @@ kickstart file:
       These sections can be in any order and are not required. Refer to
       Chapter 4, Chapter 5, and Chapter 6  for details.
 
--  The %packages, %pre, %pre-install, %post, %onerror, and %traceback sections
+-  The %certificate, %packages, %pre, %pre-install, %post, %onerror, and %traceback sections
    are all required to be closed with %end
 -  Items that are not required can be omitted.
 -  Omitting any required item will result in the installation program

--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -485,6 +485,7 @@ class BaseHandler(KickstartHandler):
 
            Instance attributes:
 
+           certificates -- A list of pykickstart.parser.Certificate instances
            packages -- An instance of pykickstart.parser.Packages which
                        describes the packages section of the input file.
            platform -- A string describing the hardware platform, which is
@@ -503,6 +504,7 @@ class BaseHandler(KickstartHandler):
 
         # This isn't really a good place for these, but it's better than
         # everything else I can think of.
+        self.certificates = []
         self.scripts = []
         self.packages = Packages()
         self.platform = ""
@@ -536,6 +538,9 @@ class BaseHandler(KickstartHandler):
                 retval += s
 
         retval += self.packages.__str__()
+
+        for cert in self.certificates:
+            retval += cert.__str__()
 
         return retval
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -195,6 +195,9 @@ class Certificate(KickstartObject):
 
     def __str__(self):
         """Return a string formatted for output to a kickstart file."""
+        if not self.cert:
+            return ""
+
         retval = "\n%certificate"
 
         retval += " --name=%s" % self.name

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -205,8 +205,6 @@ class Certificate(KickstartObject):
         if self.path:
             retval += " --path=%s\n" % self.path
 
-        pkgs = self._processCertificateBody()
-
         return retval + self.cert + "\n%end\n"
 
 

--- a/tests/certificate.py
+++ b/tests/certificate.py
@@ -11,6 +11,11 @@ VQQGEwJVUzETMBEGA1UECAwKU29tZS1TdGF0ZTEUMBIGA1UEBwwLU29tZS1TdGF0
 ...
 -----END CERTIFICATE-----"""
 
+CERT_CONTENT_2="""-----BEGIN CERTIFICATE-----
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+...
+-----END CERTIFICATE-----"""
+
 class Simple_Header_TestCase(ParserTest):
     def __init__(self, *args, **kwargs):
         ParserTest.__init__(self, *args, **kwargs)
@@ -30,18 +35,56 @@ class Simple_Header_TestCase(ParserTest):
         self.assertEqual(cert.path, "/etc/pki/ca-trust/source/anchors/")
         self.assertEqual(cert.cert, CERT_CONTENT)
 
-class Missing_Certificate_Body_Fails_TestCase(ParserTest):
+class Multiple_Terminated_TestCase(ParserTest):
     def __init__(self, *args, **kwargs):
         ParserTest.__init__(self, *args, **kwargs)
         self.ks = f"""
+%certificate --name=custom_certificate_1.pem
+{CERT_CONTENT}
+%end
+
+%certificate --name=custom_certificate_2.pem
+{CERT_CONTENT_2}
+%end
+"""
+
+    def runTest(self):
+        self.parser.readKickstartFromString(self.ks)
+        self.assertEqual(len(self.handler.certificates), 2)
+
+        # Verify the first certificate.
+        cert = self.handler.certificates[0]
+        self.assertEqual(cert.name, "custom_certificate_1.pem")
+        self.assertEqual(cert.cert, CERT_CONTENT)
+
+        # Verify the second certificate.
+        cert = self.handler.certificates[1]
+        self.assertEqual(cert.name, "custom_certificate_2.pem")
+        self.assertEqual(cert.cert, CERT_CONTENT_2)
+
+class Multiple_Unterminated_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = f"""
+%certificate --name=custom_certificate_1.pem
+{CERT_CONTENT}
+
+%certificate --name=custom_certificate_2.pem
+{CERT_CONTENT_2}
+"""
+
+    def runTest(self):
+        self.assertRaises(KickstartParseError, self.parser.readKickstartFromString, self.ks)
+
+class Missing_Certificate_Body_Fails_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = """
 %certificate --name=custom_certificate.pem --path /etc/pki/ca-trust/source/anchors/
 %end
 """
 
     def runTest(self):
-        with self.assertRaises(KickstartParseError) as context:
-            self.parser.readKickstartFromString(self.ks)
-
         self.assertRaises(KickstartParseError, self.parser.readKickstartFromString, self.ks)
 
 if __name__ == "__main__":

--- a/tests/certificate.py
+++ b/tests/certificate.py
@@ -30,5 +30,19 @@ class Simple_Header_TestCase(ParserTest):
         self.assertEqual(cert.path, "/etc/pki/ca-trust/source/anchors/")
         self.assertEqual(cert.cert, CERT_CONTENT)
 
+class Missing_Certificate_Body_Fails_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = f"""
+%certificate --name=custom_certificate.pem --path /etc/pki/ca-trust/source/anchors/
+%end
+"""
+
+    def runTest(self):
+        with self.assertRaises(KickstartParseError) as context:
+            self.parser.readKickstartFromString(self.ks)
+
+        self.assertRaises(KickstartParseError, self.parser.readKickstartFromString, self.ks)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/certificate.py
+++ b/tests/certificate.py
@@ -1,0 +1,34 @@
+import unittest
+from tests.baseclass import ParserTest
+
+from pykickstart import constants
+from pykickstart.errors import KickstartParseError
+from pykickstart import version         # pylint: disable=unused-import
+
+CERT_CONTENT="""-----BEGIN CERTIFICATE-----
+MIIDRzCCAi+gAwIBAgIJAJKb9X1rNl2YMA0GCSqGSIb3DQEBCwUAMIGFMQswCQYD
+VQQGEwJVUzETMBEGA1UECAwKU29tZS1TdGF0ZTEUMBIGA1UEBwwLU29tZS1TdGF0
+...
+-----END CERTIFICATE-----"""
+
+class Simple_Header_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = f"""
+%certificate --name=custom_certificate.pem --path /etc/pki/ca-trust/source/anchors/
+{CERT_CONTENT}
+%end
+"""
+
+    def runTest(self):
+        self.parser.readKickstartFromString(self.ks)
+        self.assertEqual(len(self.handler.certificates), 1)
+
+        # Verify the certificate defaults.
+        cert = self.handler.certificates[0]
+        self.assertEqual(cert.name, "custom_certificate.pem")
+        self.assertEqual(cert.path, "/etc/pki/ca-trust/source/anchors/")
+        self.assertEqual(cert.cert, CERT_CONTENT)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Please do not merge until changes in Anaconda are implemented as well**

This commit introduces a new `%certificate` section, allowing users to securely embed certificates directly within the kickstart file.
The section also supports an optional `--path` argument, specifying where the certificate should be installed on the target system.

Example:

%certificate --name custom_certificate.pem --path /etc/pki/ca-trust/source/anchors/ -----BEGIN CERTIFICATE-----
MIIDkDCCAnigAwIBAgIUFfTKU02DB4Nz4u3pRk1ShpRvn0AwDQYJKoZIhvcNAQEL ... -----END CERTIFICATE-----
%end