### PR TITLE
Support computer-name option for realm command (realm.py)

### DIFF
--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -57,7 +57,8 @@ class F19_Realm(KickstartCommand):
                                                        "membership-software=",
                                                        "one-time-password=",
                                                        "no-password",
-                                                       "computer-ou="))
+                                                       "computer-ou=",
+                                                       "computer-name="))
         except getopt.GetoptError as ex:
             raise KickstartParseError(_("Invalid realm arguments: %s") % ex, lineno=self.lineno)
 


### PR DESCRIPTION
Permit the `--computer-name` option to the `realm join` command. Used to allow joining where the computer object name does not match the hostname e.g. when directory serves multiple domains and the fqdn needs to be used as the object name as the hostname alone may not be unique.

The `--computer-name` was introduced into realmd in v0.16.3 in 2016 (see https://gitlab.freedesktop.org/realmd/realmd/-/tags/0.16.3).