### PR TITLE
tests: Limit the python versions used in testing

### DIFF
--- a/.github/workflows/rhel-7.yml
+++ b/.github/workflows/rhel-7.yml
@@ -1,15 +1,13 @@
-name: Tests and Coverage
+name: RHEL-7 Tests
 # Make sure only one action triggers the job, otherwise pushing to a
 # pull-request will run it twice.
 on:
   pull_request:
     branches:
-      - '*'
+      - 'rhel7-*'
   push:
     branches:
-      - master
-      - rhel10-branch
-      - rhel9-branch
+      - rhel7-branch
 
 jobs:
   unit-tests:
@@ -19,19 +17,10 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12.7"
+          - "3.6"
         include:
-          - python-version: 3.9
-            tox-env: py39
-          - python-version: "3.10"
-            tox-env: py310
-          - python-version: "3.11"
-            tox-env: py311
-          - python-version: "3.12.7"
-            tox-env: py312
+          - python-version: 3.6
+            tox-env: py36
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4
@@ -45,8 +34,3 @@ jobs:
         run: python -m pip install --upgrade pip tox
       - name: Run check coverage and docs
         run: tox -e ${{ matrix.tox-env }}
-      - name: Coveralls
-        if: ${{ matrix.python-version == '3.12.7' }}
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rhel-8.yml
+++ b/.github/workflows/rhel-8.yml
@@ -1,15 +1,13 @@
-name: Tests and Coverage
+name: RHEL-8 Tests
 # Make sure only one action triggers the job, otherwise pushing to a
 # pull-request will run it twice.
 on:
   pull_request:
     branches:
-      - '*'
+      - 'rhel8-*'
   push:
     branches:
-      - master
-      - rhel10-branch
-      - rhel9-branch
+      - rhel8-branch
 
 jobs:
   unit-tests:
@@ -19,19 +17,10 @@ jobs:
       max-parallel: 5
       matrix:
         python-version:
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12.7"
+          - "3.8"
         include:
-          - python-version: 3.9
-            tox-env: py39
-          - python-version: "3.10"
-            tox-env: py310
-          - python-version: "3.11"
-            tox-env: py311
-          - python-version: "3.12.7"
-            tox-env: py312
+          - python-version: 3.8
+            tox-env: py38
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4
@@ -45,8 +34,3 @@ jobs:
         run: python -m pip install --upgrade pip tox
       - name: Run check coverage and docs
         run: tox -e ${{ matrix.tox-env }}
-      - name: Coveralls
-        if: ${{ matrix.python-version == '3.12.7' }}
-        uses: AndreMiras/coveralls-python-action@develop
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -2,6 +2,7 @@
 
 import sys
 
+import astroid
 from pocketlint import FalsePositive, PocketLintConfig, PocketLinter
 import pylint
 
@@ -21,7 +22,7 @@ class PykickstartLintConfig(PocketLintConfig):
         return {"translation-canary", ".tox"}
 
 if __name__ == "__main__":
-    print("INFO: Using pylint v%s" % pylint.__version__)
+    print("INFO: Using pylint v%s, astroid v%s" % (pylint.version, astroid.version))
     conf = PykickstartLintConfig()
     linter = PocketLinter(conf)
     rc = linter.run()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, py311, py312, py313, mypy
+envlist = py39, py310, py311, py312, py313, mypy
 
 # python 3.6 supports pylint 2.13.9 which no longer works with translation-canary
 # only run the coverage/unit tests, not pylint.


### PR DESCRIPTION
Based on the branch name, only run a subset of the python versions. rhel7-branch uses python 3.6
rhel8-branch uses python 3.8

Run the other tests on master and on rhel9-branch and rhel10-branch.

This will allow use of python 3.9 specific features.