### PR TITLE
Makefile: Add a test-no-coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ endif
 	-$(COVERAGE) combine
 	-$(COVERAGE) report -m --include="pykickstart/*,tools/*" | tee coverage-report.log
 
+test-no-coverage:
+	@echo "*** Running unittests without coverage ***"
+	PYTHONPATH=. $(PYTHON) -m unittest -v $(tests)
+
 clean:
 	-rm *.tar.gz pykickstart/*.pyc pykickstart/*/*.pyc tests/*.pyc tests/*/*.pyc *log .coverage pykickstart.spec
 	$(MAKE) -C po clean

--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -23,7 +23,6 @@ BuildRequires: make
 
 # Only required when building with runtests
 %if %{with runtests}
-BuildRequires: python3-coverage
 BuildRequires: python3-sphinx
 %endif
 
@@ -52,7 +51,7 @@ make PYTHON=%{__python3} DESTDIR=%{buildroot} install
 
 %check
 %if %{with runtests}
-make PYTHON=%{__python3} test
+make PYTHON=%{__python3} test-no-coverage
 %endif
 
 %files


### PR DESCRIPTION
RHEL doesn't want to run coverage during rpm builds, so make a new target that just runs the tests and adjust the example .spec.in file accordingly.

Related: RHEL-61432