### PR TITLE
Update formatting of certificate section documentation

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -872,7 +872,7 @@ class CertificateSection(Section):
                             format. It will be written into a file specified by the
                             --dir and --filename options.
 
-                            Example:
+                            Example::
 
                                 %certificate --filename custom_certificate.pem --dir /etc/pki/dns/
                                 -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Fixup of commit 5d6907acf6a3901783031cf8184cdab72712fa6d

Sorry for the missing part, I should have checked that the documentation was generated as expected with the original patch, but I didn't know how to.