### PR TITLE
workflows: Switch to ubuntu-latest

### DIFF
--- a/.github/workflows/rhel-7.yml
+++ b/.github/workflows/rhel-7.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 5

--- a/.github/workflows/rhel-8.yml
+++ b/.github/workflows/rhel-8.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 5


### PR DESCRIPTION
Version 20.04 will not be supported after 4/1/2025, switch to -latest so that it will hopefully not need changes every time a release is removed.