### PR TITLE
Do not remove "md" prefix from RAID names

### DIFF
--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -334,19 +334,19 @@ class FC3_Raid(KickstartCommand):
 
         return retval
 
+    def _device_cb(self, value):
+        if value[0:2] == "md":
+            return value[2:]
+        else:
+            return value
+
+    def _level_cb(self, value):
+        if value.upper() in self.levelMap:
+            return self.levelMap[value.upper()]
+        else:
+            raise KickstartParseError(_("Invalid raid level: %s") % value, lineno=self.lineno)
+
     def _getParser(self):
-        def device_cb(value):
-            if value[0:2] == "md":
-                return value[2:]
-            else:
-                return value
-
-        def level_cb(value):
-            if value.upper() in self.levelMap:
-                return self.levelMap[value.upper()]
-            else:
-                raise KickstartParseError(_("Invalid raid level: %s") % value, lineno=self.lineno)
-
         op = KSOptionParser(prog="raid", description="""
                             Assembles a software RAID device.""",
                             epilog="""
@@ -382,7 +382,7 @@ class FC3_Raid(KickstartCommand):
                         version=FC3, help="""
                         The software raid partitions lists the RAID identifiers
                         to add to the RAID array.""")
-        op.add_argument("--device", type=device_cb, required=True,
+        op.add_argument("--device", type=self._device_cb, required=True,
                         version=FC3, help="""
                         Name of the RAID device to use (such as 'fedora-root'
                         or 'home'). As of Fedora 19, RAID devices are no longer
@@ -396,7 +396,7 @@ class FC3_Raid(KickstartCommand):
                         Other filesystems may be valid depending on command
                         line arguments passed to anaconda to enable other
                         filesystems.""")
-        op.add_argument("--level", type=level_cb, version=FC3, help="""
+        op.add_argument("--level", type=self._level_cb, version=FC3, help="""
                         RAID level to use %s.""" % set(self.levelMap.values()))
         op.add_argument("--noformat", dest="format", action="store_false",
                         default=True, version=FC3, help="""
@@ -794,3 +794,11 @@ class RHEL9_Raid(RHEL8_Raid):
 
 class RHEL10_Raid(RHEL8_Raid):
     pass
+
+class F43_Raid(F29_Raid):
+    removedKeywords = F29_Raid.removedKeywords
+    removedAttrs = F29_Raid.removedAttrs
+
+    def _device_cb(self, value):
+        # do not remove the "md" prefix from array name in F43 and later
+        return value

--- a/pykickstart/handlers/f43.py
+++ b/pykickstart/handlers/f43.py
@@ -71,7 +71,7 @@ class F43Handler(BaseHandler):
         "part": commands.partition.F41_Partition,
         "partition": commands.partition.F41_Partition,
         "poweroff": commands.reboot.F23_Reboot,
-        "raid": commands.raid.F29_Raid,
+        "raid": commands.raid.F43_Raid,
         "realm": commands.realm.F19_Realm,
         "reboot": commands.reboot.F23_Reboot,
         "repo": commands.repo.F40_Repo,

--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -410,5 +410,13 @@ class RHEL8_TestCase(F29_TestCase):
         F29_TestCase.runTest(self)
         self.assert_parse_error("raid / --device=md0 --level=1 --fstype=btrfs raid.01 raid.02")
 
+class F43_TestCase(F29_TestCase):
+    def runTest(self):
+        self.assert_parse("raid / --device=md0 --level=0 raid.01",
+                          "raid / --device=md0 --level=RAID0 raid.01\n")
+
+        self.assert_parse("raid / --device=md_test --level=1 raid.01 raid.02",
+                          "raid / --device=md_test --level=RAID1 raid.01 raid.02\n")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This used to be done when MD names were based on minor to remove the prefix from names such as "md0". This is no longer true and parsing the name in this way was removed in Fedora 19 (see d55f1adba0bdf73fc41d88e0632dfb0dbf418e8e). Removing the prefix from the name now causes issue when users use names like for example "md_xyz" and then try to use the name to refer to the new array by name in other commands like volgroup.