### PR TITLE
Do not remove "md" prefix from RAID names

### DIFF
--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -410,5 +410,13 @@ class RHEL8_TestCase(F29_TestCase):
         F29_TestCase.runTest(self)
         self.assert_parse_error("raid / --device=md0 --level=1 --fstype=btrfs raid.01 raid.02")
 
+class RHEL10_TestCase(RHEL8_TestCase):
+    def runTest(self):
+        self.assert_parse("raid / --device=md0 --level=0 raid.01",
+                          "raid / --device=md0 --level=RAID0 raid.01\n")
+
+        self.assert_parse("raid / --device=md_test --level=1 raid.01 raid.02",
+                          "raid / --device=md_test --level=RAID1 raid.01 raid.02\n")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This used to be done when MD names were based on minor to remove the prefix from names such as "md0". This is no longer true and parsing the name in this way was removed in Fedora 19 (see d55f1adba0bdf73fc41d88e0632dfb0dbf418e8e). Removing the prefix from the name now causes issue when users use names like for example "md_xyz" and then try to use the name to refer to the new array by name in other commands like volgroup.

Resolves: RHEL-80086