### PR TITLE
workflows: Add python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.11"
           - "3.12.7"
           - "3.13"
+          - "3.14.0-beta.2"
         include:
           - python-version: 3.9
             tox-env: py39
@@ -35,6 +36,8 @@ jobs:
             tox-env: py312
           - python-version: "3.13"
             tox-env: py313
+          - python-version: "3.14.0-beta.2"
+            tox-env: py314
     steps:
       - name: "Clone Repository"
         uses: actions/checkout@v4

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, py313, mypy
+envlist = py39, py310, py311, py312, py313, py314, mypy
 
 # python 3.6 supports pylint 2.13.9 which no longer works with translation-canary
 # only run the coverage/unit tests, not pylint.


### PR DESCRIPTION
Fedora 43 is using python 3.14 now, so start testing with it.