### PR TITLE
spec: drop python3-build dependency

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -17,7 +17,6 @@ Source1:   https://github.com/pykickstart/%{name}/releases/download/r%{version}/
 BuildArch: noarch
 
 BuildRequires: gettext
-BuildRequires: python3-build
 BuildRequires: python3-devel
 BuildRequires: python3-pip
 BuildRequires: python3-requests


### PR DESCRIPTION
python3-build is not available in the RHEL buildroot and is used only for make targets which are not used when building the package.