### PR TITLE
rhel-10: Add support for new bootc kickstart command

### DIFF
--- a/pykickstart/commands/__init__.py
+++ b/pykickstart/commands/__init__.py
@@ -22,6 +22,7 @@ from pykickstart.commands import (
     authselect,
     autopart,
     autostep,
+    bootc,
     bootloader,
     btrfs,
     clearpart,

--- a/pykickstart/commands/bootc.py
+++ b/pykickstart/commands/bootc.py
@@ -1,0 +1,98 @@
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pykickstart.version import RHEL10
+from pykickstart.base import KickstartCommand
+from pykickstart.options import KSOptionParser
+
+class RHEL10_Bootc(KickstartCommand):
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+    conflictingCommands = ["ostreesetup", "ostreecontainer"]
+
+    def __init__(self, *args, **kwargs):
+        KickstartCommand.__init__(self, *args, **kwargs)
+
+        self.op = self._getParser()
+
+        self.stateroot = kwargs.get('stateroot', None)
+        self.sourceImgRef = kwargs.get("sourceImgRef", None)
+        self.targetImgRef = kwargs.get("targetImgRef", self.sourceImgRef)
+
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+
+        if not self.seen:
+            return retval
+
+        retval += "# Bootc setup\n"
+        retval += "bootc %s\n" % self._getArgsAsStr()
+
+        return retval
+
+    def _getArgsAsStr(self):
+        retcmd = []
+
+        if self.stateroot:
+            retcmd.append('--stateroot="%s"' % self.stateroot)
+        if self.sourceImgRef:
+            retcmd.append('--source-imgref="%s"' % self.sourceImgRef)
+        if self.targetImgRef:
+            retcmd.append('--target-imgref="%s"' % self.targetImgRef)
+
+        return ' '.join(retcmd)
+
+    def _getParser(self):
+        op = KSOptionParser(prog="bootc", description="""
+                            Used for Bootc installations from native container. See
+                            https://bootc-dev.github.io/bootc//man/bootc-install-to-filesystem.html
+                            for more information about Bootc install to filesystem.
+                            """, version=RHEL10, conflicts=self.conflictingCommands)
+        # Rename the osname to stateroot and set default as proposed by
+        # https://github.com/ostreedev/ostree/issues/2794
+        op.add_argument("--stateroot",
+                        version=RHEL10,
+                        default="default",
+                        help="""
+                        Name for the state directory, also known as "osname".
+                        """)
+        op.add_argument("--source-imgref",
+                        dest="sourceImgRef",
+                        required=True,
+                        version=RHEL10,
+                        help="""
+                        Install the system from an explicitly given source.
+                        """)
+        op.add_argument("--target-imgref",
+                        dest="targetImgRef",
+                        version=RHEL10,
+                        help="""
+                        Specify the image to fetch for subsequent updates.
+                        If not presented defaults to '--source-imgref' value.
+                        """)
+
+        return op
+
+    def parse(self, args):
+        ns = self.op.parse_args(args=args, lineno=self.lineno)
+        self.set_to_self(ns)
+
+        if not self.targetImgRef:
+            self.targetImgRef = self.sourceImgRef
+
+        return self
+

--- a/pykickstart/commands/ostreecontainer.py
+++ b/pykickstart/commands/ostreecontainer.py
@@ -22,7 +22,7 @@ from pykickstart.options import KSOptionParser
 class F38_OSTreeContainer(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
-    conflictingCommands = ["ostreesetup"]
+    conflictingCommands = ["ostreesetup", "bootc"]
 
     def __init__(self, *args, **kwargs):
         KickstartCommand.__init__(self, *args, **kwargs)

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -23,6 +23,7 @@ from pykickstart.options import KSOptionParser
 class F21_OSTreeSetup(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
+    conflictingCommands = []
 
     def __init__(self, *args, **kwargs):
         KickstartCommand.__init__(self, *args, **kwargs)
@@ -99,4 +100,4 @@ class RHEL9_OSTreeSetup(F21_OSTreeSetup):
 class F38_OSTreeSetup(F21_OSTreeSetup):
     removedKeywords = KickstartCommand.removedKeywords
     removedAttrs = KickstartCommand.removedAttrs
-    conflictingCommands = ["ostreecontainer"]
+    conflictingCommands = ["ostreecontainer", "bootc"]

--- a/pykickstart/handlers/rhel10.py
+++ b/pykickstart/handlers/rhel10.py
@@ -30,6 +30,7 @@ class RHEL10Handler(BaseHandler):
         "authselect": commands.authselect.F28_Authselect,
         "autopart": commands.autopart.RHEL10_AutoPart,
         "autostep": commands.autostep.F40_Autostep, # RemovedCommand
+        "bootc": commands.bootc.RHEL10_Bootc,
         "bootloader": commands.bootloader.F39_Bootloader,
         "btrfs": commands.btrfs.RHEL10_BTRFS,
         "cdrom": commands.cdrom.FC3_Cdrom,

--- a/tests/commands/bootc.py
+++ b/tests/commands/bootc.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2025 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+
+import unittest
+from tests.baseclass import CommandTest, CommandSequenceTest
+from pykickstart.commands.bootc import RHEL10_Bootc
+from pykickstart.version import RHEL10
+
+class Bootc_TestCase(unittest.TestCase):
+    def runTest(self):
+        cmd = RHEL10_Bootc()
+
+        # Test arguments that are required
+        op = cmd._getParser()
+        for action in op._actions:
+            if '--source-imgref' in action.option_strings:
+                self.assertEqual(action.required, True)
+
+class RHEL10_TestCase(CommandTest):
+    command = "bootc"
+
+    def runTest(self):
+        # PASS tests
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\""
+        self.assert_parse(cmdstr)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --stateroot=\"default\""
+        self.assert_parse(cmdstr)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\""
+        cmdstr_expected = "bootc --stateroot=\"default\" --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\"" + "\n"
+        self.assert_parse(cmdstr, cmdstr_expected)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --stateroot=\"test\""
+        cmdstr_expected = "bootc --stateroot=\"test\" --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\"" + "\n"
+        self.assert_parse(cmdstr, cmdstr_expected)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --stateroot=\"test\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream10\""
+        cmdstr_expected = "bootc --stateroot=\"test\" --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream10\"" + "\n"
+        self.assert_parse(cmdstr, cmdstr_expected)
+
+
+        # FAIL tests
+        # No required argument presented
+        self.assert_parse_error("bootc")
+        self.assert_parse_error("bootc --stateroot=default")
+        self.assert_parse_error("bootc --target-imgref=default")
+
+class RHEL10_Conflict_TestCase(CommandSequenceTest):
+    def __init__(self, *args, **kwargs):
+        CommandSequenceTest.__init__(self, *args, **kwargs)
+        self.version = RHEL10
+
+    def runTest(self):
+        # FAIL tests
+        # bootc should not be used with ostreecontainer and ostreesetup
+        self.assert_parse_error("""
+        bootc --source-imgref=quay.io/centos-bootc/centos-bootc:stream9
+        ostreecontainer --url=quay.io/fedora/silverblue:stable
+        """)
+
+        self.assert_parse_error("""
+        bootc --source-imgref=quay.io/centos-bootc/centos-bootc:stream9
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core
+        """)

--- a/tests/commands/ostreecontainer.py
+++ b/tests/commands/ostreecontainer.py
@@ -19,7 +19,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.ostreecontainer import F38_OSTreeContainer
-from pykickstart.version import F38
+from pykickstart.version import F38, RHEL10
 
 class OSTreeContainer_TestCase(unittest.TestCase):
     def runTest(self):
@@ -69,4 +69,28 @@ class F38_Conflict_TestCase(CommandSequenceTest):
         self.assert_parse_error("""
         ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core
         ostreecontainer --url=quay.io/fedora/silverblue:stable
+        """)
+
+        #fail - ostreecontainer and bootc can't be used together
+        self.assert_parse_error("""
+        ostreecontainer --url=quay.io/fedora/silverblue:stable
+        bootc --source-imgref=quay.io/centos-bootc/centos-bootc:stream9
+        """)
+
+class RHEL10_Conflict_TestCase(CommandSequenceTest):
+    def __init__(self, *args, **kwargs):
+        CommandSequenceTest.__init__(self, *args, **kwargs)
+        self.version = RHEL10
+
+    def runTest(self):
+        #fail - ostreecontainer and ostreesetup can't be used together
+        self.assert_parse_error("""
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core
+        ostreecontainer --url=quay.io/fedora/silverblue:stable
+        """)
+
+        #fail - ostreecontainer and bootc can't be used together
+        self.assert_parse_error("""
+        ostreecontainer --url=quay.io/fedora/silverblue:stable
+        bootc --source-imgref=quay.io/centos-bootc/centos-bootc:stream9
         """)

--- a/tests/commands/ostreesetup.py
+++ b/tests/commands/ostreesetup.py
@@ -21,7 +21,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.ostreesetup import F21_OSTreeSetup
-from pykickstart.version import F38
+from pykickstart.version import F38, RHEL10
 
 class OSTreeSetup_TestCase(unittest.TestCase):
     def runTest(self):
@@ -82,6 +82,30 @@ class F38_Conflict_TestCase(CommandSequenceTest):
         self.assert_parse_error("""
         ostreecontainer --url=quay.io/fedora/fcos:stable
         ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core""")
+
+        #fail - ostreesetup and bootc can't be used together
+        self.assert_parse_error("""
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core
+        bootc --source-imgref=quay.io/centos-bootc/centos-bootc:stream9
+        """)
+
+class RHEL10_Conflict_TestCase(CommandSequenceTest):
+
+    def __init__(self, *args, **kwargs):
+        CommandSequenceTest.__init__(self, *args, **kwargs)
+        self.version = RHEL10
+
+    def runTest(self):
+        #fail - ostreecontainer and ostreesetup can't be used together
+        self.assert_parse_error("""
+        ostreecontainer --url=quay.io/fedora/fcos:stable
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core""")
+
+        #fail - ostreesetup and bootc can't be used together
+        self.assert_parse_error("""
+        ostreesetup --osname=fedora-atomic --url=http://example.com/repo --ref=fedora-atomic/sometest/base/core
+        bootc --source-imgref=quay.io/centos-bootc/centos-bootc:stream9
+        """)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit adds new kickstart option called "bootc". It allows to perform system installation based on bootc containers.

Related: RHEL-58215
Resolves: RHEL-132612
