### PR TITLE
Fix handling files with special characters

### DIFF
--- a/pykickstart/commands/harddrive.py
+++ b/pykickstart/commands/harddrive.py
@@ -55,9 +55,9 @@ class FC3_HardDrive(KickstartCommand):
         retval += "# Use hard drive installation media\n"
 
         if self.biospart is not None:
-            retval += "harddrive --dir=%s --biospart=%s\n" % (self.dir, self.biospart)
+            retval += "harddrive --dir=\"%s\" --biospart=%s\n" % (self.dir, self.biospart)
         else:
-            retval += "harddrive --dir=%s --partition=%s\n" % (self.dir, self.partition)
+            retval += "harddrive --dir=\"%s\" --partition=%s\n" % (self.dir, self.partition)
 
         return retval
 
@@ -111,7 +111,7 @@ class F33_HardDrive(FC3_HardDrive):
             return retval
 
         retval += "# Use hard drive installation media\n"
-        retval += "harddrive --dir=%s --partition=%s\n" % (self.dir, self.partition)
+        retval += "harddrive --dir=\"%s\" --partition=%s\n" % (self.dir, self.partition)
 
         return retval
 

--- a/pykickstart/commands/nfs.py
+++ b/pykickstart/commands/nfs.py
@@ -46,7 +46,7 @@ class FC3_NFS(KickstartCommand):
         if not self.seen:
             return retval
 
-        retval += "# Use NFS installation media\nnfs --server=%s --dir=%s\n" % (self.server, self.dir)
+        retval += "# Use NFS installation media\nnfs --server=%s --dir=\"%s\"\n" % (self.server, self.dir)
         return retval
 
     def _getParser(self):

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -200,10 +200,10 @@ class Certificate(KickstartObject):
 
         retval = "\n%certificate"
 
-        retval += " --filename=%s" % self.filename
+        retval += " --filename=\"%s\"" % self.filename
 
         if self.dir:
-            retval += " --dir=%s\n" % self.dir
+            retval += " --dir=\"%s\"\n" % self.dir
 
         return retval + self.cert + "\n%end\n"
 

--- a/tests/args_names.py
+++ b/tests/args_names.py
@@ -1,5 +1,4 @@
 import unittest
-import shlex
 import re
 
 from pykickstart.parser import KickstartParser
@@ -40,12 +39,10 @@ class ArgumentNamesStatic_TestCase(unittest.TestCase):
             if command == "method":
                 continue
 
-            args = shlex.split(command, comments=True)
-            cmd = args[0]
-
+            cmd = command.split(" ")[0]
             ks_parser = self._handler.commands[cmd]
             ks_parser.currentLine = command
-            ks_parser.currentCmd = args[0]
+            ks_parser.currentCmd = cmd
             ks_parser.seen = True
             arg_parser = ks_parser._getParser()
 

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -71,6 +71,7 @@ class ParserTest(unittest.TestCase):
             self.fail("Failed while parsing commands %s: %s" % (ks_string, e))
 
 
+
 class CommandSequenceTest(ParserTest):
     """Kickstart command sequence testing
 
@@ -145,12 +146,11 @@ class CommandTest(unittest.TestCase):
     def getParser(self, inputStr):
         '''Find a handler using the class name.  Return the requested command
         object.'''
-        args = shlex.split(inputStr, comments=True)
-        cmd = args[0]
+        cmd = inputStr.split(" ")[0]
 
         parser = self.handler().commands[cmd]  # pylint: disable=not-callable
         parser.currentLine = inputStr
-        parser.currentCmd = args[0]
+        parser.currentCmd = cmd
         parser.seen = True
 
         return parser

--- a/tests/certificate.py
+++ b/tests/certificate.py
@@ -2,6 +2,7 @@ import unittest
 from tests.baseclass import ParserTest
 
 from pykickstart.errors import KickstartParseError
+from pykickstart.parser import Certificate
 from pykickstart import version         # pylint: disable=unused-import
 
 CERT_CONTENT="""-----BEGIN CERTIFICATE-----
@@ -83,6 +84,39 @@ class Simple_Header_TestCase(ParserTest):
         self.assertEqual(cert.filename, "custom_certificate.pem")
         self.assertEqual(cert.dir, "/etc/pki/ca-trust/source/anchors/")
         self.assertEqual(cert.cert, CERT_CONTENT)
+
+class No_Closing_Quotation_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = f"""
+%certificate --filename=custom's-certificate.pem --dir=/etc/pki/edns
+{CERT_CONTENT}
+%end
+"""
+
+    def runTest(self):
+        with self.assertRaises(ValueError) as cm:
+            self.parser.readKickstartFromString(self.ks)
+
+        expected = "No closing quotation"
+        self.assertIn(expected, str(cm.exception))
+
+class Space_Without_Quotation_TestCase(ParserTest):
+    def __init__(self, *args, **kwargs):
+        ParserTest.__init__(self, *args, **kwargs)
+        self.ks = f"""
+%certificate --filename=custom certificate.pem --dir=/etc/pki/edns
+{CERT_CONTENT}
+%end
+"""
+
+    def runTest(self):
+        with self.assertRaises(KickstartParseError) as cm:
+            self.parser.readKickstartFromString(self.ks)
+
+        expected = "unrecognized arguments: certificate.pem"
+        self.assertIn(expected, str(cm.exception))
+
 
 class Missing_Dir_TestCase(ParserTest):
     def __init__(self, *args, **kwargs):
@@ -194,6 +228,16 @@ class Cert_Content_Empty_Line_TestCase(ParserTest):
         cert = self.handler.certificates[1]
         self.assertEqual(cert.filename, "custom_certificate_2.pem")
         self.assertEqual(cert.cert, CERT_CONTENT_WITH_TRAILING_NEWLINE)
+
+class Certificate_Quoting_TestCase(unittest.TestCase):
+    def runTest(self):
+        complicated_dir = """/very /s'trange/ path"""
+        expected_list = ["--filename=\"%s\"" % complicated_dir, "--dir=\"%s\"" % complicated_dir]
+        data = Certificate(cert="cert", dir=complicated_dir, filename=complicated_dir)
+        line = [line[len("%certificate "):] for line in str(data).splitlines() if line.startswith("%certificate ")][0]
+        for item in expected_list:
+            with self.subTest(item=item):
+                self.assertIn(item, line)
 
 
 if __name__ == "__main__":

--- a/tests/commands/harddrive.py
+++ b/tests/commands/harddrive.py
@@ -52,20 +52,31 @@ class HardDrive_TestCase(unittest.TestCase):
                        data1, data2,
                        ['biospart', 'partition', 'dir'])
 
+        complicated_dir = """/OS ISO/dir iso's/the.iso"""
+        expected_dir = "--dir=\"%s\"" % complicated_dir
+        data3 = FC3_HardDrive(dir=complicated_dir)
+        data3.seen = True
+        line3 = [line[len("harddrive "):] for line in str(data3).splitlines() if line.startswith("harddrive ")][0]
+        assert expected_dir in line3
+        data4 = FC3_HardDrive(dir=complicated_dir, biospart="sda1")
+        data4.seen = True
+        line4 = [line[len("harddrive "):] for line in str(data4).splitlines() if line.startswith("harddrive ")][0]
+        assert expected_dir in line4
+
 
 class FC3_TestCase(CommandTest):
     def runTest(self):
         # pass
-        self.assert_parse("harddrive --dir=/install --biospart=part", "harddrive --dir=/install --biospart=part\n")
-        self.assert_parse("harddrive --dir=/install --partition=part", "harddrive --dir=/install --partition=part\n")
+        self.assert_parse("harddrive --dir=/install --biospart=part", "harddrive --dir=\"/install\" --biospart=part\n")
+        self.assert_parse("harddrive --dir=/install --partition=part", "harddrive --dir=\"/install\" --partition=part\n")
 
-        self.assertFalse(self.assert_parse("harddrive --dir=/install --partition=sda1") is None)
-        self.assertTrue(self.assert_parse("harddrive --dir=/install --partition=sda1") !=
-                        self.assert_parse("harddrive --dir=/install --partition=sda2"))
-        self.assertFalse(self.assert_parse("harddrive --dir=/install --biospart=80p1") ==
-                         self.assert_parse("harddrive --dir=/install --biospart=80p2"))
-        self.assertFalse(self.assert_parse("harddrive --dir=/install --biospart=sda1") ==
-                         self.assert_parse("harddrive --dir=/other-install --biospart=sda1"))
+        self.assertFalse(self.assert_parse("harddrive --dir=\"/install\" --partition=sda1") is None)
+        self.assertTrue(self.assert_parse("harddrive --dir=\"/install\" --partition=sda1") !=
+                        self.assert_parse("harddrive --dir=\"/install\" --partition=sda2"))
+        self.assertFalse(self.assert_parse("harddrive --dir=\"/install\" --biospart=80p1") ==
+                         self.assert_parse("harddrive --dir=\"/install\" --biospart=80p2"))
+        self.assertFalse(self.assert_parse("harddrive --dir=\"/install\" --biospart=sda1") ==
+                         self.assert_parse("harddrive --dir=\"/other-install\" --biospart=sda1"))
 
         # fail
         # required option --dir missing
@@ -73,12 +84,12 @@ class FC3_TestCase(CommandTest):
         # required --dir argument missing
         self.assert_parse_error("harddrive --dir")
         # missing --biospart or --partition option
-        self.assert_parse_error("harddrive --dir=/install")
+        self.assert_parse_error("harddrive --dir=\"/install\"")
         # both --biospart and --partition specified
-        self.assert_parse_error("harddrive --dir=/install --biospart=bios --partition=part")
+        self.assert_parse_error("harddrive --dir=\"/install\" --biospart=bios --partition=part")
         # --biospart and --partition require argument
-        self.assert_parse_error("harddrive --dir=/install --biospart")
-        self.assert_parse_error("harddrive --dir=/install --partition")
+        self.assert_parse_error("harddrive --dir=\"/install\" --biospart")
+        self.assert_parse_error("harddrive --dir=\"/install\" --partition")
         # unknown option
         self.assert_parse_error("harddrive --unknown=value")
 
@@ -92,14 +103,21 @@ class F33HardDrive_TestCase(unittest.TestCase):
                        data1, data2,
                        ['partition', 'dir'])
 
+        complicated_dir = "/OS ISO/dir iso's/the.iso"
+        expected_dir = "--dir=\"%s\"" % complicated_dir
+        data3 = F33_HardDrive(dir=complicated_dir)
+        data3.seen = True
+        line3 = [line[len("harddrive "):] for line in str(data3).splitlines() if line.startswith("harddrive ")][0]
+        assert expected_dir in line3
+
 
 class F33_TestCase(CommandTest):
     def runTest(self):
         # pass
-        self.assert_parse("harddrive --dir=/install --partition=part", "harddrive --dir=/install --partition=part\n")
-        self.assertFalse(self.assert_parse("harddrive --dir=/install --partition=sda1") is None)
-        self.assertTrue(self.assert_parse("harddrive --dir=/install --partition=sda1") !=
-                        self.assert_parse("harddrive --dir=/install --partition=sda2"))
+        self.assert_parse("harddrive --dir=\"/install\" --partition=part", "harddrive --dir=\"/install\" --partition=part\n")
+        self.assertFalse(self.assert_parse("harddrive --dir=\"/install\" --partition=sda1") is None)
+        self.assertTrue(self.assert_parse("harddrive --dir=\"/install\" --partition=sda1") !=
+                        self.assert_parse("harddrive --dir=\"/install\" --partition=sda2"))
 
         # fail
         # Ensure these options have been removed.
@@ -109,7 +127,7 @@ class F33_TestCase(CommandTest):
         # required --dir argument missing
         self.assert_parse_error("harddrive --dir")
         # missing --partition option
-        self.assert_parse_error("harddrive --dir=/install")
+        self.assert_parse_error("harddrive --dir=\"/install\"")
         # missing --dir option
         self.assert_parse_error("harddrive --partition=sda1")
         # unknown option

--- a/tests/commands/method.py
+++ b/tests/commands/method.py
@@ -18,8 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 
-import unittest
 import copy
+import unittest
 from tests.baseclass import CommandTest
 from pykickstart.base import DeprecatedCommand, RemovedCommand
 
@@ -189,11 +189,16 @@ class FC3_TestCase(CommandTest):
 
         # harddrive
         if "biospart" not in self.handler.commandMap["harddrive"].removedKeywords:
-            self.assert_parse("harddrive --dir=/install --biospart=part", "harddrive --dir=/install --biospart=part\n")
-        self.assert_parse("harddrive --dir=/install --partition=part", "harddrive --dir=/install --partition=part\n")
+            self.assert_parse("harddrive --dir=\"/install\" --biospart=part", "harddrive --dir=\"/install\" --biospart=part\n")
+        self.assert_parse("harddrive --dir=\"/install\" --partition=part", "harddrive --dir=\"/install\" --partition=part\n")
+
+        complicated_dir = """/OS ISO/dir iso's/the.iso"""
+        self.assert_parse("harddrive --dir=\"%s\" --partition=part" % complicated_dir)
+
 
         # nfs
-        self.assert_parse("nfs --server=1.2.3.4 --dir=/install", "nfs --server=1.2.3.4 --dir=/install\n")
+        self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\"", "nfs --server=1.2.3.4 --dir=\"/install\"\n")
+        self.assert_parse("nfs --server=1.2.3.4 --dir=\"%s\"" % complicated_dir)
 
         # url
         self.assert_parse("url --url=http://domain.com", "url --url=\"http://domain.com\"\n")
@@ -205,24 +210,37 @@ class FC3_TestCase(CommandTest):
         # required --dir argument missing
         self.assert_parse_error("harddrive --dir")
         # missing --biospart or --partition option
-        self.assert_parse_error("harddrive --dir=/install")
+        self.assert_parse_error("harddrive --dir=\"/install\"")
         # both --biospart and --partition specified
-        self.assert_parse_error("harddrive --dir=/install --biospart=bios --partition=part")
+        self.assert_parse_error("harddrive --dir=\"/install\" --biospart=bios --partition=part")
         # --biospart and --partition require argument
-        self.assert_parse_error("harddrive --dir=/install --biospart")
-        self.assert_parse_error("harddrive --dir=/install --partition")
+        self.assert_parse_error("harddrive --dir=\"/install\" --biospart")
+        self.assert_parse_error("harddrive --dir=\"/install\" --partition")
         # unknown option
         self.assert_parse_error("harddrive --unknown=value")
+        # Space without quotation
+        self.assert_parse_error("harddrive --dir=/OS /space.iso --partition=/sdb3")
+
+        # No closing quotation
+        with self.assertRaises(ValueError, msg="No closing quotation"):
+            self.assert_parse("harddrive --biospart=bios --dir=/the'/thingy.iso")
+        with self.assertRaises(ValueError, msg="No closing quotation"):
+            self.assert_parse("harddrive --biospart=bios --dir=/the\"/thingy.iso")
 
         # nfs
         # missing required options --server and --dir
         self.assert_parse_error("nfs")
         self.assert_parse_error("nfs --server=1.2.3.4")
         self.assert_parse_error("nfs --server")
-        self.assert_parse_error("nfs --dir=/install")
+        self.assert_parse_error("nfs --dir=\"/install\"")
         self.assert_parse_error("nfs --dir")
         # unknown option
         self.assert_parse_error("nfs --unknown=value")
+        # No closing quotation
+        with self.assertRaises(ValueError, msg="No closing quotation"):
+            self.assert_parse_error("nfs --server=1.2.3.4 --dir=/'oops")
+        # Space without quotation
+        self.assert_parse_error("nfs --server=1.2.3.4 --dir=/ oops", regex="unrecognized arguments: oops")
 
         # url
         # missing required option --url
@@ -236,12 +254,12 @@ class FC6_TestCase(FC3_TestCase):
 
         # pass
         # nfs
-        self.assert_parse("nfs --server=1.2.3.4 --dir=/install --opts=options", "nfs --server=1.2.3.4 --dir=/install --opts=\"options\"\n")
+        self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\" --opts=options", "nfs --server=1.2.3.4 --dir=\"/install\" --opts=\"options\"\n")
 
         # fail
         # nfs
         # --opts requires argument if specified
-        self.assert_parse_error("nfs --server=1.2.3.4 --dir=/install --opts")
+        self.assert_parse_error("nfs --server=1.2.3.4 --dir=\"/install\" --opts")
 
 
 class F13_TestCase(FC6_TestCase):

--- a/tests/commands/nfs.py
+++ b/tests/commands/nfs.py
@@ -49,22 +49,22 @@ class NFS_TestCase(unittest.TestCase):
 class FC3_TestCase(CommandTest):
     def runTest(self):
         # pass
-        self.assert_parse("nfs --server=1.2.3.4 --dir=/install", "nfs --server=1.2.3.4 --dir=/install\n")
+        self.assert_parse("nfs --server=1.2.3.4 --dir=/install", "nfs --server=1.2.3.4 --dir=\"/install\"\n")
 
-        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=/install") is None)
-        self.assertTrue(self.assert_parse("nfs --server=1.2.3.4 --dir=/install") !=
-                        self.assert_parse("nfs --server=2.3.4.5 --dir=/install"))
-        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=/install") ==
-                         self.assert_parse("nfs --server=2.3.4.5 --dir=/install"))
-        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=/install") ==
-                         self.assert_parse("nfs --server=1.2.3.4 --dir=/install2"))
+        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\"") is None)
+        self.assertTrue(self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\"") !=
+                        self.assert_parse("nfs --server=2.3.4.5 --dir=\"/install\""))
+        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\"") ==
+                         self.assert_parse("nfs --server=2.3.4.5 --dir=\"/install\""))
+        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\"") ==
+                         self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install2\""))
 
         # fail
         # missing required options --server and --dir
         self.assert_parse_error("nfs")
         self.assert_parse_error("nfs --server=1.2.3.4")
         self.assert_parse_error("nfs --server")
-        self.assert_parse_error("nfs --dir=/install")
+        self.assert_parse_error("nfs --dir=\"/install\"")
         self.assert_parse_error("nfs --dir")
         # unknown option
         self.assert_parse_error("nfs --unknown=value")
@@ -75,16 +75,16 @@ class FC6_TestCase(FC3_TestCase):
         FC3_TestCase.runTest(self)
 
         # pass
-        self.assert_parse("nfs --server=1.2.3.4 --dir=/install --opts=options", "nfs --server=1.2.3.4 --dir=/install --opts=\"options\"\n")
+        self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\" --opts=options", "nfs --server=1.2.3.4 --dir=\"/install\" --opts=\"options\"\n")
 
-        self.assertTrue(self.assert_parse("nfs --server=1.2.3.4 --dir=/install --opts=options") ==
-                        self.assert_parse("nfs --server=1.2.3.4 --dir=/install --opts=options"))
-        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=/install --opts=options") ==
-                         self.assert_parse("nfs --server=1.2.3.4 --dir=/install --opts=other,options"))
+        self.assertTrue(self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\" --opts=options") ==
+                        self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\" --opts=options"))
+        self.assertFalse(self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\" --opts=options") ==
+                         self.assert_parse("nfs --server=1.2.3.4 --dir=\"/install\" --opts=other,options"))
 
         # fail
         # --opts requires argument if specified
-        self.assert_parse_error("nfs --server=1.2.3.4 --dir=/install --opts")
+        self.assert_parse_error("nfs --server=1.2.3.4 --dir=\"/install\" --opts")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It is not always possible to guarantee that the user wrote the media with the method the distribution provided. Enforce quoting to avoid parsing errors from missing quotation end and recognizing an value with spaces as another argument.

Example:

        harddrive --dir=/OS ISO/torrent iso's/Qubes-R4.3.0-x86_64/Qubes-R4.3.0-x86_64.iso --partition=sda2

Fixes: https://github.com/QubesOS/qubes-issues/issues/8993

---

About the choice of single quotes instead of double quotes: some places uses one or the other, I just chose single quotes to avoid making the diff bigger having to escape double quotes or change quote order.