### PR TITLE
bootc: Add bootloader and composefs arguments

### DIFF
--- a/pykickstart/commands/bootc.py
+++ b/pykickstart/commands/bootc.py
@@ -15,7 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pykickstart.version import F43
+from pykickstart.version import F43, F45
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
 
@@ -102,3 +102,37 @@ class F43_Bootc(KickstartCommand):
 
         return self
 
+class F45_Bootc(F43_Bootc):
+    removedKeywords = F43_Bootc.removedKeywords
+    removedAttrs = F43_Bootc.removedAttrs
+
+    def __init__(self, *args, **kwargs):
+        F43_Bootc.__init__(self, *args, **kwargs)
+        self.bootloader = kwargs.get("bootloader", None)
+        self.composefs = kwargs.get("composefs", False)
+
+    def _getArgsAsStr(self):
+        retval = F43_Bootc._getArgsAsStr(self)
+
+        if self.bootloader:
+            retval += ' --bootloader="%s"' % self.bootloader
+        if self.composefs:
+            retval += " --composefs"
+
+        return retval
+
+    def _getParser(self):
+        op = F43_Bootc._getParser(self)
+        op.add_argument("--bootloader",
+                        version=F45,
+                        help="""
+                        Bootloader selection: none, grub, systemd
+                        """)
+        op.add_argument("--composefs",
+                        version=F45,
+                        action="store_true",
+                        default=False,
+                        help="""
+                        Use the composefs backend instead of the the default which is ostree.
+                        """)
+        return op

--- a/pykickstart/handlers/f45.py
+++ b/pykickstart/handlers/f45.py
@@ -30,7 +30,7 @@ class F45Handler(BaseHandler):
         "authselect": commands.authselect.F28_Authselect,
         "autopart": commands.autopart.F41_AutoPart,
         "autostep": commands.autostep.F40_Autostep, # RemovedCommand
-        "bootc": commands.bootc.F43_Bootc,
+        "bootc": commands.bootc.F45_Bootc,
         "bootloader": commands.bootloader.F39_Bootloader,
         "btrfs": commands.btrfs.F23_BTRFS,
         "cdrom": commands.cdrom.FC3_Cdrom,

--- a/tests/commands/bootc.py
+++ b/tests/commands/bootc.py
@@ -81,3 +81,23 @@ class F43_Conflict_TestCase(CommandSequenceTest):
 
 class RHEL10_TestCase(F43_TestCase):
     pass
+
+class F45_TestCase(F43_TestCase):
+    command = "bootc"
+
+    def runTest(self):
+        # PASS tests
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --bootloader=grub --composefs"
+        self.assert_parse(cmdstr)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --bootloader=grub"
+        cmdstr_expected = "bootc --stateroot=\"default\" --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --bootloader=\"grub\"" + "\n"
+        self.assert_parse(cmdstr, cmdstr_expected)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --composefs"
+        cmdstr_expected = "bootc --stateroot=\"default\" --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --composefs" + "\n"
+        self.assert_parse(cmdstr, cmdstr_expected)
+
+        cmdstr = "bootc --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --bootloader=grub --composefs"
+        cmdstr_expected = "bootc --stateroot=\"default\" --source-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --target-imgref=\"quay.io/centos-bootc/centos-bootc:stream9\" --bootloader=\"grub\" --composefs" + "\n"
+        self.assert_parse(cmdstr, cmdstr_expected)


### PR DESCRIPTION
Use --bootloader=[none|grub|systemd] to select bootloader. Use --composefs to use the composefs backend instead of ostree.

Also includes tests.

Fixes #567