### PR TITLE
Fix RHEL document handling

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -34,7 +34,9 @@ apidoc:
 html: apidoc
 	./gen_commands_docs > commands.rst
 	./gen_commands_docs RHEL8 > commands_rhel8.rst
-	./gen_commands_docs RHEL9 > commands_rhel.rst
+	./gen_commands_docs RHEL9 > commands_rhel9.rst
+	./gen_commands_docs RHEL10 > commands_rhel.rst
+	./gen_commands_docs RHEL11 > commands_rhel11.rst
 	./gen_sections_docs > sections.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -33,10 +33,12 @@ apidoc:
 
 html: apidoc
 	./gen_commands_docs > commands.rst
-	./gen_commands_docs RHEL8 > commands_rhel8.rst
-	./gen_commands_docs RHEL9 > commands_rhel9.rst
+	# RHEL10 is embedded in kickstart-docs, don't set title
 	./gen_commands_docs RHEL10 > commands_rhel.rst
-	./gen_commands_docs RHEL11 > commands_rhel11.rst
+	# Generate docs for other versions of RHEL
+	./gen_commands_docs RHEL8 "RHEL 8" > commands_rhel8.rst
+	./gen_commands_docs RHEL9 "RHEL 9" > commands_rhel9.rst
+	./gen_commands_docs RHEL11 "RHEL 11" > commands_rhel11.rst
 	./gen_sections_docs > sections.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo

--- a/docs/gen_commands_docs
+++ b/docs/gen_commands_docs
@@ -12,8 +12,11 @@ def _format_title(title):
 
 if __name__ == "__main__":
     handler_version = DEVEL
+    page_title_prefix = None
     if len(sys.argv) > 1:
         handler_version = stringToVersion(sys.argv[1])
+    if len(sys.argv) > 2:
+        page_title_prefix = sys.argv[2]
     handler_string = versionToString(handler_version)
 
     # build a list of all possible commands, with their respective latest versions
@@ -44,6 +47,9 @@ if __name__ == "__main__":
                 last_version = getVersionFromCommandClass(all_commands[command_name])
                 if command_version > last_version:
                     all_commands[command_name] = command_class
+
+    if page_title_prefix:
+        print(f".. title:: {page_title_prefix}")
 
     # now loop over all commands and document them
     already_documented = []

--- a/docs/kickstart-docs.rst
+++ b/docs/kickstart-docs.rst
@@ -249,9 +249,10 @@ pykickstart processes arguments to commands just like the shell does:
    arguments list, they must be escaped.
 
 .. note::
-    Documentation for RHEL 8 commands can be `found here <commands_rhel8.html>`_
+    Documentation for RHEL 8 can be `found here <commands_rhel8.html>`_, and
+    Documentation for RHEL 9 can be `found here <commands_rhel9.html>`_
 
-Commands for RHEL 9:
+Commands for RHEL 10:
 
 .. include:: commands_rhel.rst
 


### PR DESCRIPTION
The RHEL docs section was still pointing to RHEL9, and standalone pages were difficult to distinguish. This switches to using RHEL10 in the main document, moving RHEL9 to a standalone page, and adds the release version to the title string.