### PR TITLE
Enable Packit COPR builds for Fedora rawhide

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,7 +1,36 @@
-specfile_path: pykickstart.spec.in
-synced_files:
-  - packit.yaml
-  - pykickstart.spec.in
-upstream_project_name: pykickstart
+specfile_path: pykickstart.spec
+upstream_package_name: pykickstart
 downstream_package_name: pykickstart
-dist_git_url: https://src.fedoraproject.org/rpms/pykickstart.git
+
+srpm_build_deps:
+  - git
+  - gettext
+  - make
+  - python3-devel
+  - python3-pip
+  - python3-setuptools
+  - python3-build
+  - python3-sphinx
+
+actions:
+  get-current-version:
+    - python3 setup.py --version
+  create-archive:
+    - make local WEBLATE_BRANCH=master
+    - bash -c "ls *.tar*"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-rawhide
+    branch: master
+
+  - job: copr_build
+    trigger: commit
+    targets:
+      - fedora-rawhide
+    branch: master
+    owner: "@rhinstaller"
+    project: Pykickstart
+    preserve_project: True


### PR DESCRIPTION
Add copr_build jobs on pull requests and commits to main. Persistent repo: @rhinstaller/Pykickstart [1]

[1] https://copr.fedorainfracloud.org/coprs/g/rhinstaller/Pykickstart/