### PR TITLE
Fix filename typo in condition

### DIFF
--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -358,7 +358,7 @@ class PostScriptSection(ScriptSection):
     installed::
 
         %post --nochroot
-        if [ ! -e /mnt/sysimage/etc/resolf.conf ]; then
+        if [ ! -e /mnt/sysimage/etc/resolv.conf ]; then
             cp -P /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
         fi
         %end


### PR DESCRIPTION
The condition if the resolv.conf exists in the sysimage path should check for the correct filename