### PR TITLE
spec: do not depend on pytest-cov, nor pytest-xdist on RHEL

### DIFF
--- a/pykickstart.spec.in
+++ b/pykickstart.spec.in
@@ -23,8 +23,9 @@ BuildRequires: python3-requests
 BuildRequires: python3-setuptools
 BuildRequires: make
 BuildRequires: python3-pytest
+%if %{undefined rhel}
 BuildRequires: python3-pytest-xdist
-BuildRequires: python3-pytest-cov
+%endif
 
 # Only required when building with runtests
 %if %{with runtests}
@@ -46,6 +47,10 @@ the pykickstart package.
 
 %prep
 %setup -q
+%if %{defined rhel}
+# no xdist, run tests serially
+sed -i -e '/pytest/s/ -n auto / /' Makefile
+%endif
 
 %build
 make PYTHON=%{__python3}


### PR DESCRIPTION
Coverage tests are not run during the package build, in line with Fedora
packaging policy.  xdist is not included in RHEL, so the tests need to be
run serially.

Related: https://src.fedoraproject.org/rpms/pykickstart/pull-request/7
